### PR TITLE
Agregar impresión con personalización de medicamentos

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,10 +7,7 @@ import InsulinForm from './components/InsulinForm';
 import SchedulePreview from './components/SchedulePreview';
 import TrashIcon from './components/icons/TrashIcon';
 import ControlInfoForm from './components/ControlInfoForm';
-
-// Declare jsPDF and html2canvas to be available in the global scope from the CDN
-declare const jspdf: any;
-declare const html2canvas: any;
+import MoneyIcon from './components/icons/MoneyIcon';
 
 const initialControlInfo: ControlInfo = {
     applies: 'yes',
@@ -62,49 +59,18 @@ const App: React.FC = () => {
         setControlInfo(prev => ({...prev, [field]: value}));
     }, []);
 
-    const handleExportPDF = () => {
-        const input = previewRef.current;
-        if (!input) {
-            console.error("Preview element not found");
+    const handlePrint = () => {
+        const content = previewRef.current?.innerHTML;
+        if (!content) {
+            console.error('Preview element not found');
             return;
         }
-
-        const { jsPDF } = jspdf;
-        const pdf = new jsPDF({
-            orientation: 'p',
-            unit: 'px',
-            format: 'a4',
-            putOnlyUsedFonts:true,
-            floatPrecision: 16
-        });
-
-        // Temporarily change width to a fixed one for consistent PDF output
-        const originalWidth = input.style.width;
-        input.style.width = '700px';
-
-        html2canvas(input, {
-             scale: 2, // Higher scale for better quality
-             useCORS: true 
-        }).then((canvas) => {
-            const imgData = canvas.toDataURL('image/png');
-            
-            const pdfWidth = pdf.internal.pageSize.getWidth();
-            
-            const imgProps= pdf.getImageProperties(imgData);
-            const imgWidth = pdfWidth;
-            const imgHeight = (imgProps.height * imgWidth) / imgProps.width;
-            
-            pdf.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
-            
-            // Restore original width
-            input.style.width = originalWidth;
-
-            pdf.save(`cartola_${patient.name.replace(/\s/g, '_') || 'paciente'}.pdf`);
-        }).catch(err => {
-            console.error("Error generating PDF:", err);
-            // Restore original width on error
-            input.style.width = originalWidth;
-        });
+        const printWindow = window.open('', '', 'width=800,height=600');
+        if (!printWindow) return;
+        printWindow.document.write(`<!DOCTYPE html><html><head><title>Cartola de Medicamentos</title><script src="https://cdn.tailwindcss.com"></script></head><body>${content}</body></html>`);
+        printWindow.document.close();
+        printWindow.focus();
+        printWindow.print();
     };
 
     return (
@@ -113,13 +79,11 @@ const App: React.FC = () => {
                 <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
                     <h1 className="text-2xl font-bold text-blue-700">Generador de Cartola de Medicamentos</h1>
                     <button
-                        onClick={handleExportPDF}
+                        onClick={handlePrint}
                         className="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-2"
                     >
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                            <path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" />
-                        </svg>
-                        Exportar a PDF
+                        <span role="img" aria-label="Imprimir" className="text-xl">🖨️</span>
+                        Imprimir / Guardar PDF
                     </button>
                 </div>
             </header>
@@ -139,7 +103,7 @@ const App: React.FC = () => {
                                 {medications.map((med) => (
                                     <li key={med.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
                                         <div>
-                                            <p className="font-bold text-blue-600">{med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span></p>
+                                            <p className="font-bold text-blue-600">{med.externalPurchase && <MoneyIcon className="inline mr-1" />}{med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span></p>
                                             <p className="text-sm text-slate-500">{`${med.dose} comprimido(s) - ${med.frequency}`}</p>
                                             {med.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {med.notes}</p>}
                                         </div>

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -12,14 +12,15 @@ const initialMedState = {
     dose: Dose.ONE,
     frequency: Frequency.EVERY_12H,
     notes: '',
+    externalPurchase: false,
 };
 
 const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
     const [medication, setMedication] = useState(initialMedState);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-        const { name, value } = e.target;
-        setMedication(prev => ({ ...prev, [name]: value }));
+        const { name, value, type, checked } = e.target as HTMLInputElement;
+        setMedication(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
     };
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -102,6 +103,17 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
                     rows={2}
                     className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                 />
+            </div>
+            <div className="flex items-center gap-2">
+                <input
+                    type="checkbox"
+                    id="externalPurchase"
+                    name="externalPurchase"
+                    checked={medication.externalPurchase}
+                    onChange={handleChange}
+                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-slate-300 rounded"
+                />
+                <label htmlFor="externalPurchase" className="text-sm text-slate-600">Debe ser comprado por el paciente</label>
             </div>
             <button
                 type="submit"

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -4,6 +4,7 @@ import DoseVisualizer from './DoseVisualizer';
 import MoonIcon from './icons/MoonIcon';
 import SunIcon from './icons/SunIcon';
 import InsulinDoseVisualizer from './InsulinDoseVisualizer';
+import MoneyIcon from './icons/MoneyIcon';
 
 interface SchedulePreviewProps {
     patient: Patient;
@@ -114,21 +115,21 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                 if (item.itemType === 'medication') {
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
-                                            <td className="p-4 align-top">
-                                                <p className="font-bold text-md text-slate-800">{item.name}</p>
+                                            <td className="p-4 align-top" contentEditable suppressContentEditableWarning>
+                                                <p className="font-bold text-md text-slate-800">{item.externalPurchase && <MoneyIcon className="inline mr-1" />}{item.name}</p>
                                                 <p className="text-sm text-slate-600">{item.presentacion}</p>
                                                 <p className="text-xs text-slate-500 italic">{`${item.dose} comp. - ${item.frequency}`}</p>
                                             </td>
-                                            <td className="p-4 text-center align-middle">
+                                            <td className="p-4 text-center align-middle" contentEditable suppressContentEditableWarning>
                                                 {shouldShowDose(item.frequency, 'morning') && <DoseVisualizer dose={item.dose} className="text-blue-600" />}
                                             </td>
-                                            <td className="p-4 text-center align-middle">
+                                            <td className="p-4 text-center align-middle" contentEditable suppressContentEditableWarning>
                                                 {shouldShowDose(item.frequency, 'afternoon') && <DoseVisualizer dose={item.dose} className="text-amber-500" />}
                                             </td>
-                                            <td className="p-4 text-center align-middle">
+                                            <td className="p-4 text-center align-middle" contentEditable suppressContentEditableWarning>
                                                 {shouldShowDose(item.frequency, 'night') && <DoseVisualizer dose={item.dose} className="text-blue-600" />}
                                             </td>
-                                            <td className="p-4 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
+                                            <td className="p-4 align-top text-sm text-slate-700 whitespace-pre-wrap break-words" contentEditable suppressContentEditableWarning>
                                                 {item.notes || ''}
                                             </td>
                                         </tr>
@@ -140,28 +141,28 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                         .join('\n');
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
-                                            <td className="p-4 align-top">
+                                            <td className="p-4 align-top" contentEditable suppressContentEditableWarning>
                                                 <p className="font-bold text-md text-slate-800">{item.type}</p>
                                                 <p className="text-sm text-teal-600">Insulina</p>
                                             </td>
-                                            <td className="p-4 text-center align-middle">
+                                            <td className="p-4 text-center align-middle" contentEditable suppressContentEditableWarning>
                                                 <div className="flex flex-col items-center gap-2">
                                                     {item.schedules.mañana.map(ins => (
                                                         <InsulinDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
-                                            <td className="p-4 text-center align-middle">
+                                            <td className="p-4 text-center align-middle" contentEditable suppressContentEditableWarning>
                                                 {/* Insulin typically not in the afternoon */}
                                             </td>
-                                            <td className="p-4 text-center align-middle">
+                                            <td className="p-4 text-center align-middle" contentEditable suppressContentEditableWarning>
                                                  <div className="flex flex-col items-center gap-2">
                                                     {item.schedules.noche.map(ins => (
                                                         <InsulinDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
-                                            <td className="p-4 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
+                                            <td className="p-4 align-top text-sm text-slate-700 whitespace-pre-wrap break-words" contentEditable suppressContentEditableWarning>
                                                 {allNotes}
                                             </td>
                                         </tr>

--- a/components/icons/MoneyIcon.tsx
+++ b/components/icons/MoneyIcon.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MoneyIcon = ({ className }: { className?: string }) => (
+  <span role="img" aria-label="billete" className={className}>💵</span>
+);
+
+export default MoneyIcon;

--- a/index.html
+++ b/index.html
@@ -6,8 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Generador de Cartola de Medicamentos</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 <script type="importmap">
 {
   "imports": {

--- a/types.ts
+++ b/types.ts
@@ -1,8 +1,8 @@
 export enum Frequency {
-  EVERY_24H = 'Cada 24 horas (mañana)',
-  EVERY_24H_NIGHT = 'Cada 24 horas (noche)',
-  EVERY_12H = 'Cada 12 horas',
-  EVERY_8H = 'Cada 8 horas',
+  EVERY_24H = 'cada 24 horas (mañana)',
+  EVERY_24H_NIGHT = 'cada 24 horas (noche)',
+  EVERY_12H = 'cada 12 horas',
+  EVERY_8H = 'cada 8 horas',
   MORNING = 'Solo en la mañana',
   AFTERNOON = 'Solo en la tarde',
   NIGHT = 'Solo en la noche',
@@ -25,6 +25,7 @@ export interface Medication {
   dose: Dose;
   frequency: Frequency;
   notes?: string;
+  externalPurchase?: boolean;
 }
 
 export interface Patient {


### PR DESCRIPTION
## Resumen
- Reemplazar exportación a PDF por opción de imprimir/guardar mediante diálogo del navegador.
- Permitir marcar medicamentos que deben comprarse externamente e indicar con icono de billete.
- Ajustar textos de frecuencia a "cada" y hacer la tabla del horario editable.

## Pruebas
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7bfb803bc832cb0658c3cd9098cce