### PR TITLE
Enable print dialog and editable medication doses

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,10 +7,7 @@ import InjectableForm from './components/InjectableForm';
 import SchedulePreview from './components/SchedulePreview';
 import TrashIcon from './components/icons/TrashIcon';
 import ControlInfoForm from './components/ControlInfoForm';
-
-// Declare jsPDF and html2canvas to be available in the global scope from the CDN
-declare const jspdf: any;
-declare const html2canvas: any;
+import MoneyIcon from './components/icons/MoneyIcon';
 
 const initialControlInfo: ControlInfo = {
     applies: 'no',
@@ -65,49 +62,8 @@ const App: React.FC = () => {
         setControlInfo(prev => ({...prev, [field]: value}));
     }, []);
 
-    const handleExportPDF = () => {
-        const input = previewRef.current;
-        if (!input) {
-            console.error("Preview element not found");
-            return;
-        }
-
-        const { jsPDF } = jspdf;
-        const pdf = new jsPDF({
-            orientation: 'p',
-            unit: 'px',
-            format: 'a4',
-            putOnlyUsedFonts:true,
-            floatPrecision: 16
-        });
-
-        // Temporarily change width to a fixed one for consistent PDF output
-        const originalWidth = input.style.width;
-        input.style.width = '700px';
-
-        html2canvas(input, {
-             scale: 2, // Higher scale for better quality
-             useCORS: true 
-        }).then((canvas) => {
-            const imgData = canvas.toDataURL('image/png');
-            
-            const pdfWidth = pdf.internal.pageSize.getWidth();
-            
-            const imgProps= pdf.getImageProperties(imgData);
-            const imgWidth = pdfWidth;
-            const imgHeight = (imgProps.height * imgWidth) / imgProps.width;
-            
-            pdf.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
-            
-            // Restore original width
-            input.style.width = originalWidth;
-
-            pdf.save(`cartola_${patient.name.replace(/\s/g, '_') || 'paciente'}.pdf`);
-        }).catch(err => {
-            console.error("Error generating PDF:", err);
-            // Restore original width on error
-            input.style.width = originalWidth;
-        });
+    const handlePrint = () => {
+        window.print();
     };
 
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -161,13 +117,13 @@ const App: React.FC = () => {
                         </button>
                         <input ref={fileInputRef} type="file" accept="application/json" className="hidden" onChange={handleImportList} />
                         <button
-                            onClick={handleExportPDF}
+                            onClick={handlePrint}
                             className="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-2"
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                <path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" />
+                                <path fillRule="evenodd" d="M6 2a2 2 0 00-2 2v2h12V4a2 2 0 00-2-2H6zm10 6H4v8a2 2 0 002 2h8a2 2 0 002-2V8zM6 10h8v2H6v-2z" clipRule="evenodd" />
                             </svg>
-                            Exportar a PDF
+                            Imprimir / Guardar PDF
                         </button>
                     </div>
                 </div>
@@ -188,7 +144,10 @@ const App: React.FC = () => {
                                 {medications.map((med) => (
                                     <li key={med.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
                                         <div>
-                                            <p className="font-bold text-blue-600">{med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span></p>
+                                            <p className="font-bold text-blue-600">
+                                                {med.requiresPurchase && <MoneyIcon className="inline w-4 h-4 mr-1" />}
+                                                {med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span>
+                                            </p>
                                             <p className="text-sm text-slate-500">{`${med.dose} comprimido(s) - ${med.frequency}`}</p>
                                             {med.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {med.notes}</p>}
                                         </div>

--- a/components/DoseVisualizer.tsx
+++ b/components/DoseVisualizer.tsx
@@ -43,10 +43,47 @@ const DoseVisualizer: React.FC<DoseVisualizerProps> = ({ dose, className }) => {
                     <HalfPillIcon className="w-8 h-8" />
                 </DoseDisplay>
             );
+        case Dose.THREE_QUARTERS:
+            return (
+                <DoseDisplay label={Dose.THREE_QUARTERS}>
+                    <div className="flex items-center justify-center -space-x-4">
+                        <HalfPillIcon className="w-8 h-8" />
+                        <QuarterPillIcon className="w-8 h-8" />
+                    </div>
+                </DoseDisplay>
+            );
         case Dose.ONE:
              return (
                 <DoseDisplay label={Dose.ONE}>
                     <PillIcon className="w-10 h-10" />
+                </DoseDisplay>
+            );
+        case Dose.ONE_AND_QUARTER:
+            return (
+                <DoseDisplay label={Dose.ONE_AND_QUARTER}>
+                    <div className="flex items-center justify-center -space-x-4">
+                        <PillIcon className="w-10 h-10" />
+                        <QuarterPillIcon className="w-8 h-8" />
+                    </div>
+                </DoseDisplay>
+            );
+        case Dose.ONE_AND_HALF:
+            return (
+                <DoseDisplay label={Dose.ONE_AND_HALF}>
+                    <div className="flex items-center justify-center -space-x-4">
+                        <PillIcon className="w-10 h-10" />
+                        <HalfPillIcon className="w-8 h-8" />
+                    </div>
+                </DoseDisplay>
+            );
+        case Dose.ONE_AND_THREE_QUARTERS:
+            return (
+                <DoseDisplay label={Dose.ONE_AND_THREE_QUARTERS}>
+                    <div className="flex items-center justify-center -space-x-4">
+                        <PillIcon className="w-10 h-10" />
+                        <HalfPillIcon className="w-8 h-8" />
+                        <QuarterPillIcon className="w-8 h-8" />
+                    </div>
                 </DoseDisplay>
             );
         case Dose.TWO:

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -6,19 +6,21 @@ interface MedicationFormProps {
     onAddMedication: (med: Omit<Medication, 'id'>) => void;
 }
 
-const initialMedState = {
+const initialMedState: Omit<Medication, 'id'> = {
     name: '',
     presentacion: '',
     dose: Dose.ONE,
     frequency: Frequency.EVERY_12H,
     notes: '',
+    requiresPurchase: false,
 };
 
 const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
     const [medication, setMedication] = useState(initialMedState);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-        const { name, value } = e.target;
+        const { name, type } = e.target;
+        const value = type === 'checkbox' ? (e.target as HTMLInputElement).checked : e.target.value;
         setMedication(prev => ({ ...prev, [name]: value }));
     };
 
@@ -90,6 +92,17 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
                         ))}
                     </select>
                 </div>
+            </div>
+            <div className="flex items-center">
+                <input
+                    type="checkbox"
+                    id="requiresPurchase"
+                    name="requiresPurchase"
+                    checked={medication.requiresPurchase}
+                    onChange={handleChange}
+                    className="mr-2"
+                />
+                <label htmlFor="requiresPurchase" className="text-sm text-slate-600">Paciente compra este medicamento</label>
             </div>
             <div>
                 <label htmlFor="notes" className="block text-sm font-medium text-slate-600 mb-1">Notas (Opcional)</label>

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import { Patient, Medication, Frequency, Injectable, InjectableSchedule, InjectableType, ControlInfo } from '../types';
+import React, { useState, useEffect } from 'react';
+import { Patient, Medication, Frequency, Dose, Injectable, InjectableSchedule, InjectableType, ControlInfo } from '../types';
 import DoseVisualizer from './DoseVisualizer';
 import MoonIcon from './icons/MoonIcon';
 import SunIcon from './icons/SunIcon';
 import InjectableDoseVisualizer from './InjectableDoseVisualizer';
+import MoneyIcon from './icons/MoneyIcon';
 
 interface SchedulePreviewProps {
     patient: Patient;
@@ -13,7 +14,7 @@ interface SchedulePreviewProps {
 }
 
 const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, controlInfo }) => {
-    
+
     const shouldShowDose = (freq: Frequency, time: 'morning' | 'afternoon' | 'night'): boolean => {
         switch (time) {
             case 'morning':
@@ -25,6 +26,50 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
             default:
                 return false;
         }
+    };
+
+    const doseOrder: Dose[] = [
+        Dose.QUARTER,
+        Dose.HALF,
+        Dose.THREE_QUARTERS,
+        Dose.ONE,
+        Dose.ONE_AND_QUARTER,
+        Dose.ONE_AND_HALF,
+        Dose.ONE_AND_THREE_QUARTERS,
+        Dose.TWO,
+        Dose.THREE,
+        Dose.FOUR,
+    ];
+
+    const initializeDoses = (meds: Medication[]) => {
+        const map: Record<number, { morning: Dose | null; afternoon: Dose | null; night: Dose | null }> = {};
+        meds.forEach(med => {
+            map[med.id] = {
+                morning: shouldShowDose(med.frequency, 'morning') ? med.dose : null,
+                afternoon: shouldShowDose(med.frequency, 'afternoon') ? med.dose : null,
+                night: shouldShowDose(med.frequency, 'night') ? med.dose : null,
+            };
+        });
+        return map;
+    };
+
+    const [editableDoses, setEditableDoses] = useState<Record<number, { morning: Dose | null; afternoon: Dose | null; night: Dose | null }>>(() => initializeDoses(medications));
+
+    useEffect(() => {
+        setEditableDoses(initializeDoses(medications));
+    }, [medications]);
+
+    const cycleDose = (current: Dose | null): Dose | null => {
+        if (current === null) return doseOrder[0];
+        const idx = doseOrder.indexOf(current);
+        return idx === -1 || idx === doseOrder.length - 1 ? null : doseOrder[idx + 1];
+    };
+
+    const handleDoseClick = (medId: number, time: 'morning' | 'afternoon' | 'night') => {
+        setEditableDoses(prev => {
+            const next = cycleDose(prev[medId][time]);
+            return { ...prev, [medId]: { ...prev[medId], [time]: next } };
+        });
     };
 
     const groupedInjectables = injectables.reduce((acc, inj) => {
@@ -104,24 +149,31 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                 <th className="p-3 text-left font-semibold text-sm w-1/6">Notas</th>
                             </tr>
                         </thead>
-                        <tbody>
+                        <tbody contentEditable suppressContentEditableWarning>
                             {allItems.length > 0 ? allItems.map((item, index) => {
                                 if (item.itemType === 'medication') {
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
                                             <td className="p-4 align-top">
-                                                <p className="font-bold text-md text-slate-800">{item.name}</p>
+                                                <p className="font-bold text-md text-slate-800">
+                                                    {item.requiresPurchase && (
+                                                        <span contentEditable={false}>
+                                                            <MoneyIcon className="inline w-4 h-4 mr-1 text-green-600" />
+                                                        </span>
+                                                    )}
+                                                    {item.name}
+                                                </p>
                                                 <p className="text-sm text-slate-600">{item.presentacion}</p>
                                                 <p className="text-xs text-slate-500 italic">{`${item.dose} comp. - ${item.frequency}`}</p>
                                             </td>
-                                            <td className="p-4 text-center align-middle">
-                                                {shouldShowDose(item.frequency, 'morning') && <DoseVisualizer dose={item.dose} className="text-blue-600" />}
+                                            <td className="p-4 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'morning')}>
+                                                {editableDoses[item.id]?.morning && <DoseVisualizer dose={editableDoses[item.id].morning} className="text-blue-600" />}
                                             </td>
-                                            <td className="p-4 text-center align-middle">
-                                                {shouldShowDose(item.frequency, 'afternoon') && <DoseVisualizer dose={item.dose} className="text-amber-500" />}
+                                            <td className="p-4 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'afternoon')}>
+                                                {editableDoses[item.id]?.afternoon && <DoseVisualizer dose={editableDoses[item.id].afternoon} className="text-amber-500" />}
                                             </td>
-                                            <td className="p-4 text-center align-middle">
-                                                {shouldShowDose(item.frequency, 'night') && <DoseVisualizer dose={item.dose} className="text-blue-600" />}
+                                            <td className="p-4 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'night')}>
+                                                {editableDoses[item.id]?.night && <DoseVisualizer dose={editableDoses[item.id].night} className="text-blue-600" />}
                                             </td>
                                             <td className="p-4 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
                                                 {item.notes || ''}
@@ -139,17 +191,17 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                 <p className="font-bold text-md text-slate-800">{item.type}</p>
                                                 <p className="text-sm text-teal-600">Inyectable</p>
                                             </td>
-                                            <td className="p-4 text-center align-middle">
+                                            <td className="p-4 text-center align-middle" contentEditable={false}>
                                                 <div className="flex flex-col items-center gap-2">
                                                     {item.schedules.mañana.map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
-                                            <td className="p-4 text-center align-middle">
+                                            <td className="p-4 text-center align-middle" contentEditable={false}>
                                                 {/* typically not used in the afternoon */}
                                             </td>
-                                            <td className="p-4 text-center align-middle">
+                                            <td className="p-4 text-center align-middle" contentEditable={false}>
                                                  <div className="flex flex-col items-center gap-2">
                                                     {item.schedules.noche.map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>

--- a/components/icons/MoneyIcon.tsx
+++ b/components/icons/MoneyIcon.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const MoneyIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className || 'w-5 h-5 text-green-600'}
+  >
+    <rect x="2" y="5" width="20" height="14" rx="2" />
+    <path
+      d="M12 8.5c1.5 0 2.5-.6 2.5-1.5S13.5 5.5 12 5.5s-2.5.6-2.5 1.5S10.5 8.5 12 8.5zm0 7c-1.5 0-2.5.6-2.5 1.5S10.5 19.5 12 19.5s2.5-.6 2.5-1.5S13.5 15.5 12 15.5zm-3.5-5h7m-7 4h7"
+      stroke="white"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+    <path d="M12 7v10" stroke="white" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+export default MoneyIcon;

--- a/index.html
+++ b/index.html
@@ -6,8 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Generador de Cartola de Medicamentos</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <style>
+      @media print {
+        body * { visibility: hidden; }
+        #schedule-preview, #schedule-preview * { visibility: visible; }
+        #schedule-preview { position: absolute; left: 0; top: 0; width: 100%; }
+      }
+    </style>
 <script type="importmap">
 {
   "imports": {

--- a/types.ts
+++ b/types.ts
@@ -1,18 +1,22 @@
 export enum Frequency {
-  EVERY_24H = 'Cada 24 horas (mañana)',
-  EVERY_24H_NIGHT = 'Cada 24 horas (noche)',
-  EVERY_12H = 'Cada 12 horas',
-  EVERY_8H = 'Cada 8 horas',
+  EVERY_24H = 'cada 24 horas (mañana)',
+  EVERY_24H_NIGHT = 'cada 24 horas (noche)',
+  EVERY_12H = 'cada 12 horas',
+  EVERY_8H = 'cada 8 horas',
   MORNING = 'Solo en la mañana',
   AFTERNOON = 'Solo en la tarde',
   NIGHT = 'Solo en la noche',
-  WITH_MEALS = 'Con cada comida principal',
+  WITH_MEALS = 'con cada comida principal',
 }
 
 export enum Dose {
     QUARTER = '1/4',
     HALF = '1/2',
+    THREE_QUARTERS = '3/4',
     ONE = '1',
+    ONE_AND_QUARTER = '1 1/4',
+    ONE_AND_HALF = '1 1/2',
+    ONE_AND_THREE_QUARTERS = '1 3/4',
     TWO = '2',
     THREE = '3',
     FOUR = '4',
@@ -25,6 +29,7 @@ export interface Medication {
   dose: Dose;
   frequency: Frequency;
   notes?: string;
+  requiresPurchase?: boolean;
 }
 
 export interface Patient {


### PR DESCRIPTION
## Summary
- replace PDF export with print dialog and add print styles
- allow editing doses directly in the schedule, cycling through fractional values
- add optional money icon to mark medications to be bought by the patient and lowercase frequency labels

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a7c90cb954832ca081efcda241c8e1