### PR TITLE
Compact medication table and form with numbering

### DIFF
--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -33,9 +33,9 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
     };
 
     return (
-        <form onSubmit={handleSubmit} className="space-y-4 pt-4 border-t border-slate-200">
+        <form onSubmit={handleSubmit} className="space-y-2 pt-2 border-t border-slate-200">
             <h2 className="text-2xl font-bold text-slate-800 border-b-2 border-blue-200 pb-2">Añadir Medicamento</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
                     <label htmlFor="medName" className="block text-sm font-medium text-slate-600 mb-1">Nombre del Medicamento</label>
                     <input
@@ -45,7 +45,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
                         value={medication.name}
                         onChange={handleChange}
                         placeholder="Ej: Losartán"
-                        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
@@ -58,12 +58,12 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
                         value={medication.presentacion}
                         onChange={handleChange}
                         placeholder="Ej: 50mg"
-                        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
             </div>
-             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
                     <label htmlFor="dose" className="block text-sm font-medium text-slate-600 mb-1">Dosis (comprimidos)</label>
                     <select
@@ -71,7 +71,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
                         name="dose"
                         value={medication.dose}
                         onChange={handleChange}
-                        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                     >
                         {Object.values(Dose).map(d => (
                             <option key={d} value={d}>{d}</option>
@@ -85,7 +85,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
                         name="frequency"
                         value={medication.frequency}
                         onChange={handleChange}
-                        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                     >
                         {Object.values(Frequency).map(freq => (
                             <option key={freq} value={freq}>{freq}</option>
@@ -113,12 +113,12 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
                     onChange={handleChange}
                     placeholder="Ej: Tomar con abundante agua"
                     rows={2}
-                    className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                    className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                 />
             </div>
             <button
                 type="submit"
-                className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center justify-center gap-2"
+                className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center justify-center gap-2"
             >
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                     <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -128,25 +128,26 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                     <table className="w-full border-collapse">
                         <thead>
                             <tr className="bg-blue-600 text-white">
-                                <th className="p-3 text-left font-semibold text-sm w-1/3">Medicamento / Presentación</th>
-                                <th className="p-3 text-center font-semibold text-sm w-1/6">
-                                    <div className="flex flex-col items-center justify-center gap-1">
-                                        <SunIcon className="w-6 h-6" />
+                                <th className="p-2 text-center font-semibold text-sm w-12">#</th>
+                                <th className="p-2 text-left font-semibold text-sm w-1/3">Medicamento / Presentación</th>
+                                <th className="p-2 text-center font-semibold text-sm w-1/6">
+                                    <div className="flex flex-col items-center justify-center gap-0.5">
+                                        <SunIcon className="w-5 h-5" />
                                         <span>Mañana</span>
                                     </div>
                                 </th>
-                                <th className="p-3 text-center font-semibold text-sm w-1/6">
-                                    <div className="flex flex-col items-center justify-center gap-1">
+                                <th className="p-2 text-center font-semibold text-sm w-1/6">
+                                    <div className="flex flex-col items-center justify-center gap-0.5">
                                         <span>Tarde</span>
                                     </div>
                                 </th>
-                                <th className="p-3 text-center font-semibold text-sm w-1/6">
-                                    <div className="flex flex-col items-center justify-center gap-1">
-                                        <MoonIcon className="w-6 h-6" />
+                                <th className="p-2 text-center font-semibold text-sm w-1/6">
+                                    <div className="flex flex-col items-center justify-center gap-0.5">
+                                        <MoonIcon className="w-5 h-5" />
                                         <span>Noche</span>
                                     </div>
                                 </th>
-                                <th className="p-3 text-left font-semibold text-sm w-1/6">Notas</th>
+                                <th className="p-2 text-left font-semibold text-sm w-1/6">Notas</th>
                             </tr>
                         </thead>
                         <tbody contentEditable suppressContentEditableWarning>
@@ -154,7 +155,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                 if (item.itemType === 'medication') {
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
-                                            <td className="p-4 align-top">
+                                            <td className="p-2 text-center align-top">{index + 1}</td>
+                                            <td className="p-2 align-top">
                                                 <p className="font-bold text-md text-slate-800">
                                                     {item.requiresPurchase && (
                                                         <span contentEditable={false}>
@@ -166,16 +168,16 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                 <p className="text-sm text-slate-600">{item.presentacion}</p>
                                                 <p className="text-xs text-slate-500 italic">{`${item.dose} comp. - ${item.frequency}`}</p>
                                             </td>
-                                            <td className="p-4 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'morning')}>
+                                            <td className="p-2 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'morning')}>
                                                 {editableDoses[item.id]?.morning && <DoseVisualizer dose={editableDoses[item.id].morning} className="text-blue-600" />}
                                             </td>
-                                            <td className="p-4 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'afternoon')}>
+                                            <td className="p-2 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'afternoon')}>
                                                 {editableDoses[item.id]?.afternoon && <DoseVisualizer dose={editableDoses[item.id].afternoon} className="text-amber-500" />}
                                             </td>
-                                            <td className="p-4 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'night')}>
+                                            <td className="p-2 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'night')}>
                                                 {editableDoses[item.id]?.night && <DoseVisualizer dose={editableDoses[item.id].night} className="text-blue-600" />}
                                             </td>
-                                            <td className="p-4 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
+                                            <td className="p-2 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
                                                 {item.notes || ''}
                                             </td>
                                         </tr>
@@ -187,28 +189,29 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                         .join('\n');
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
-                                            <td className="p-4 align-top">
+                                            <td className="p-2 text-center align-top">{index + 1}</td>
+                                            <td className="p-2 align-top">
                                                 <p className="font-bold text-md text-slate-800">{item.type}</p>
                                                 <p className="text-sm text-teal-600">Inyectable</p>
                                             </td>
-                                            <td className="p-4 text-center align-middle" contentEditable={false}>
+                                            <td className="p-2 text-center align-middle" contentEditable={false}>
                                                 <div className="flex flex-col items-center gap-2">
                                                     {item.schedules.mañana.map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
-                                            <td className="p-4 text-center align-middle" contentEditable={false}>
+                                            <td className="p-2 text-center align-middle" contentEditable={false}>
                                                 {/* typically not used in the afternoon */}
                                             </td>
-                                            <td className="p-4 text-center align-middle" contentEditable={false}>
+                                            <td className="p-2 text-center align-middle" contentEditable={false}>
                                                  <div className="flex flex-col items-center gap-2">
                                                     {item.schedules.noche.map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
-                                            <td className="p-4 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
+                                            <td className="p-2 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
                                                 {allNotes}
                                             </td>
                                         </tr>
@@ -216,7 +219,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                 }
                             }) : (
                                 <tr>
-                                    <td colSpan={5} className="text-center p-8 text-slate-500">
+                                    <td colSpan={6} className="text-center p-4 text-slate-500">
                                         <p>Añada un medicamento o tratamiento inyectable para verlo aquí.</p>
                                     </td>
                                 </tr>


### PR DESCRIPTION
## Summary
- Add numbering column to schedule table and shrink padding for a more compact layout.
- Trim vertical spacing in medication entry form to save space.

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cf8012e4832c959e97cc5fa640a0