### PR TITLE
Add medication descriptors and suspension notes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useRef, useCallback } from 'react';
-import { Patient, Medication, Injectable, ControlInfo, ExamOptions } from './types';
+import { Patient, Medication, Injectable, ControlInfo, ExamOptions, MedicationDescriptor } from './types';
 import PatientInfoForm from './components/PatientInfoForm';
 import MedicationForm from './components/MedicationForm';
 import InjectableForm from './components/InjectableForm';
@@ -8,6 +8,9 @@ import SchedulePreview from './components/SchedulePreview';
 import TrashIcon from './components/icons/TrashIcon';
 import ControlInfoForm from './components/ControlInfoForm';
 import MoneyIcon from './components/icons/MoneyIcon';
+import ArrowUpIcon from './components/icons/ArrowUpIcon';
+import ArrowDownIcon from './components/icons/ArrowDownIcon';
+import NewIcon from './components/icons/NewIcon';
 
 const initialControlInfo: ControlInfo = {
     applies: 'no',
@@ -69,7 +72,7 @@ const App: React.FC = () => {
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const handleExportList = () => {
-        const data = { medications, injectables };
+        const data = { patient, medications, injectables };
         const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
@@ -88,6 +91,13 @@ const App: React.FC = () => {
                 const data = JSON.parse(ev.target?.result as string);
                 setMedications(data.medications || []);
                 setInjectables(data.injectables || []);
+                if (data.patient) {
+                    setPatient({
+                        name: data.patient.name || '',
+                        rut: data.patient.rut || '',
+                        date: data.patient.date || today,
+                    });
+                }
             } catch (err) {
                 console.error('Error al importar lista', err);
             }
@@ -145,7 +155,15 @@ const App: React.FC = () => {
                                     <li key={med.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
                                         <div>
                                             <p className="font-bold text-blue-600">
-                                                {med.requiresPurchase && <MoneyIcon className="inline w-4 h-4 mr-1" />}
+                                                {med.descriptors?.map(desc => {
+                                                    const Icon = {
+                                                        [MedicationDescriptor.BUY_OUTSIDE]: MoneyIcon,
+                                                        [MedicationDescriptor.DOSE_INCREASE]: ArrowUpIcon,
+                                                        [MedicationDescriptor.DOSE_DECREASE]: ArrowDownIcon,
+                                                        [MedicationDescriptor.NEW]: NewIcon,
+                                                    }[desc];
+                                                    return <Icon key={desc} className="inline w-4 h-4 mr-1" />;
+                                                })}
                                                 {med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span>
                                             </p>
                                             <p className="text-sm text-slate-500">{`${med.dose} comprimido(s) - ${med.frequency}`}</p>

--- a/components/ControlInfoForm.tsx
+++ b/components/ControlInfoForm.tsx
@@ -43,6 +43,18 @@ const ControlInfoForm: React.FC<ControlInfoFormProps> = ({ controlInfo, onChange
                 </select>
             </div>
 
+            <div>
+                <label htmlFor="professional" className="block text-sm font-medium text-slate-600 mb-1">Profesional</label>
+                <input
+                    type="text"
+                    id="professional"
+                    name="professional"
+                    value={controlInfo.professional}
+                    onChange={(e) => onChange('professional', e.target.value)}
+                    className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                />
+            </div>
+
             {controlInfo.applies === 'yes' && (
                 <div className="space-y-4 pt-2">
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -68,17 +80,6 @@ const ControlInfoForm: React.FC<ControlInfoFormProps> = ({ controlInfo, onChange
                                 className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                             />
                         </div>
-                    </div>
-                    <div>
-                        <label htmlFor="professional" className="block text-sm font-medium text-slate-600 mb-1">Profesional</label>
-                        <input
-                            type="text"
-                            id="professional"
-                            name="professional"
-                            value={controlInfo.professional}
-                            onChange={(e) => onChange('professional', e.target.value)}
-                            className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                        />
                     </div>
                     <div>
                         <label htmlFor="withExams" className="block text-sm font-medium text-slate-600 mb-1">Con Exámenes</label>

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -1,6 +1,10 @@
 
 import React, { useState } from 'react';
-import { Medication, Frequency, Dose } from '../types';
+import { Medication, Frequency, Dose, MedicationDescriptor } from '../types';
+import MoneyIcon from './icons/MoneyIcon';
+import ArrowUpIcon from './icons/ArrowUpIcon';
+import ArrowDownIcon from './icons/ArrowDownIcon';
+import NewIcon from './icons/NewIcon';
 
 interface MedicationFormProps {
     onAddMedication: (med: Omit<Medication, 'id'>) => void;
@@ -12,16 +16,27 @@ const initialMedState: Omit<Medication, 'id'> = {
     dose: Dose.ONE,
     frequency: Frequency.EVERY_12H,
     notes: '',
-    requiresPurchase: false,
+    descriptors: [],
 };
 
 const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
     const [medication, setMedication] = useState(initialMedState);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-        const { name, type } = e.target;
-        const value = type === 'checkbox' ? (e.target as HTMLInputElement).checked : e.target.value;
+        const { name, value } = e.target;
         setMedication(prev => ({ ...prev, [name]: value }));
+    };
+
+    const toggleDescriptor = (desc: MedicationDescriptor) => {
+        setMedication(prev => {
+            const hasDesc = prev.descriptors.includes(desc);
+            return {
+                ...prev,
+                descriptors: hasDesc
+                    ? prev.descriptors.filter(d => d !== desc)
+                    : [...prev.descriptors, desc],
+            };
+        });
     };
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -63,7 +78,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
                     />
                 </div>
             </div>
-             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
                     <label htmlFor="dose" className="block text-sm font-medium text-slate-600 mb-1">Dosis (comprimidos)</label>
                     <select
@@ -93,16 +108,43 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication }) => {
                     </select>
                 </div>
             </div>
-            <div className="flex items-center">
-                <input
-                    type="checkbox"
-                    id="requiresPurchase"
-                    name="requiresPurchase"
-                    checked={medication.requiresPurchase}
-                    onChange={handleChange}
-                    className="mr-2"
-                />
-                <label htmlFor="requiresPurchase" className="text-sm text-slate-600">Paciente compra este medicamento</label>
+            <div className="flex flex-wrap items-center gap-4">
+                <label className="flex items-center text-sm text-slate-600">
+                    <input
+                        type="checkbox"
+                        className="mr-1"
+                        checked={medication.descriptors.includes(MedicationDescriptor.BUY_OUTSIDE)}
+                        onChange={() => toggleDescriptor(MedicationDescriptor.BUY_OUTSIDE)}
+                    />
+                    <MoneyIcon className="w-4 h-4 mr-1" /> Comprar afuera
+                </label>
+                <label className="flex items-center text-sm text-slate-600">
+                    <input
+                        type="checkbox"
+                        className="mr-1"
+                        checked={medication.descriptors.includes(MedicationDescriptor.DOSE_INCREASE)}
+                        onChange={() => toggleDescriptor(MedicationDescriptor.DOSE_INCREASE)}
+                    />
+                    <ArrowUpIcon className="w-4 h-4 mr-1" /> Aumento de dosis
+                </label>
+                <label className="flex items-center text-sm text-slate-600">
+                    <input
+                        type="checkbox"
+                        className="mr-1"
+                        checked={medication.descriptors.includes(MedicationDescriptor.DOSE_DECREASE)}
+                        onChange={() => toggleDescriptor(MedicationDescriptor.DOSE_DECREASE)}
+                    />
+                    <ArrowDownIcon className="w-4 h-4 mr-1" /> Disminución de dosis
+                </label>
+                <label className="flex items-center text-sm text-slate-600">
+                    <input
+                        type="checkbox"
+                        className="mr-1"
+                        checked={medication.descriptors.includes(MedicationDescriptor.NEW)}
+                        onChange={() => toggleDescriptor(MedicationDescriptor.NEW)}
+                    />
+                    <NewIcon className="w-4 h-4 mr-1" /> Nuevo fármaco
+                </label>
             </div>
             <div>
                 <label htmlFor="notes" className="block text-sm font-medium text-slate-600 mb-1">Notas (Opcional)</label>

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -1,10 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { Patient, Medication, Frequency, Dose, Injectable, InjectableSchedule, InjectableType, ControlInfo } from '../types';
+import { Patient, Medication, Frequency, Dose, Injectable, InjectableSchedule, InjectableType, ControlInfo, MedicationDescriptor } from '../types';
 import DoseVisualizer from './DoseVisualizer';
 import MoonIcon from './icons/MoonIcon';
 import SunIcon from './icons/SunIcon';
 import InjectableDoseVisualizer from './InjectableDoseVisualizer';
 import MoneyIcon from './icons/MoneyIcon';
+import ArrowUpIcon from './icons/ArrowUpIcon';
+import ArrowDownIcon from './icons/ArrowDownIcon';
+import NewIcon from './icons/NewIcon';
+import StopIcon from './icons/StopIcon';
 
 interface SchedulePreviewProps {
     patient: Patient;
@@ -158,11 +162,19 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                             <td className="p-2 text-center align-top">{index + 1}</td>
                                             <td className="p-2 align-top">
                                                 <p className="font-bold text-md text-slate-800">
-                                                    {item.requiresPurchase && (
-                                                        <span contentEditable={false}>
-                                                            <MoneyIcon className="inline w-4 h-4 mr-1 text-green-600" />
-                                                        </span>
-                                                    )}
+                                                    {item.descriptors?.map(desc => {
+                                                        const Icon = {
+                                                            [MedicationDescriptor.BUY_OUTSIDE]: MoneyIcon,
+                                                            [MedicationDescriptor.DOSE_INCREASE]: ArrowUpIcon,
+                                                            [MedicationDescriptor.DOSE_DECREASE]: ArrowDownIcon,
+                                                            [MedicationDescriptor.NEW]: NewIcon,
+                                                        }[desc];
+                                                        return (
+                                                            <span key={desc} contentEditable={false}>
+                                                                <Icon className="inline w-4 h-4 mr-1" />
+                                                            </span>
+                                                        );
+                                                    })}
                                                     {item.name}
                                                 </p>
                                                 <p className="text-sm text-slate-600">{item.presentacion}</p>
@@ -229,7 +241,18 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                 </div>
             </section>
 
-             {controlInfo.applies === 'yes' && controlInfo.date && (
+            <section className="mt-6" contentEditable={false}>
+                <h3 className="text-md font-bold text-red-600 flex items-center gap-1">
+                    <StopIcon className="w-5 h-5 text-red-600" /> Suspender los siguientes medicamentos
+                </h3>
+                <div
+                    className="mt-2 border border-red-300 rounded p-2 h-16"
+                    contentEditable
+                    suppressContentEditableWarning
+                ></div>
+            </section>
+
+            {controlInfo.applies === 'yes' && controlInfo.date && (
                 <section className="mt-6 pt-4 border-t border-slate-200 text-xs">
                     <h3 className="text-lg font-bold text-slate-800 mb-2 text-center">Próximo Control Médico</h3>
                     <div className="bg-slate-50 rounded-lg p-3 grid grid-cols-1 md:grid-cols-2 gap-3">

--- a/components/icons/ArrowDownIcon.tsx
+++ b/components/icons/ArrowDownIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const ArrowDownIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className || 'w-5 h-5 text-blue-600'}
+  >
+    <path
+      fillRule="evenodd"
+      d="M12 20a.75.75 0 01-.53-.22l-5.25-5.25a.75.75 0 111.06-1.06L11.25 17.19V4a.75.75 0 011.5 0v13.19l3.97-3.97a.75.75 0 111.06 1.06l-5.25 5.25A.75.75 0 0112 20z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+export default ArrowDownIcon;

--- a/components/icons/ArrowUpIcon.tsx
+++ b/components/icons/ArrowUpIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const ArrowUpIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className || 'w-5 h-5 text-blue-600'}
+  >
+    <path
+      fillRule="evenodd"
+      d="M12 4a.75.75 0 01.53.22l5.25 5.25a.75.75 0 11-1.06 1.06L12.75 6.81V20a.75.75 0 01-1.5 0V6.81L7.28 10.53a.75.75 0 11-1.06-1.06l5.25-5.25A.75.75 0 0112 4z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+export default ArrowUpIcon;

--- a/components/icons/NewIcon.tsx
+++ b/components/icons/NewIcon.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const NewIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className || 'w-5 h-5 text-purple-600'}
+  >
+    <rect x="2" y="2" width="20" height="20" rx="3" />
+    <text
+      x="12"
+      y="16"
+      textAnchor="middle"
+      fontSize="10"
+      fontFamily="Arial, sans-serif"
+      fill="white"
+    >
+      NEW
+    </text>
+  </svg>
+);
+
+export default NewIcon;

--- a/components/icons/StopIcon.tsx
+++ b/components/icons/StopIcon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const StopIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className || 'w-5 h-5 text-red-600'}
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="7" y1="7" x2="17" y2="17" stroke="white" strokeWidth="2" />
+    <line x1="17" y1="7" x2="7" y2="17" stroke="white" strokeWidth="2" />
+  </svg>
+);
+
+export default StopIcon;

--- a/types.ts
+++ b/types.ts
@@ -22,6 +22,13 @@ export enum Dose {
     FOUR = '4',
 }
 
+export enum MedicationDescriptor {
+  BUY_OUTSIDE = 'buyOutside',
+  DOSE_INCREASE = 'doseIncrease',
+  DOSE_DECREASE = 'doseDecrease',
+  NEW = 'newMedication',
+}
+
 export interface Medication {
   id: number;
   name: string;
@@ -29,7 +36,7 @@ export interface Medication {
   dose: Dose;
   frequency: Frequency;
   notes?: string;
-  requiresPurchase?: boolean;
+  descriptors?: MedicationDescriptor[];
 }
 
 export interface Patient {


### PR DESCRIPTION
## Summary
- allow multiple descriptors per medication with icons
- retain patient info on import/export and always show professional name field
- add section to note medications to suspend

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7e18ffeb4832cbc9bc13b080b31c2