### PR TITLE
Add edit icons and update dose visuals

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -326,6 +326,17 @@ const App: React.FC = () => {
                     </div>
 
                     <SuspensionSection controlInfo={controlInfo} onChange={handleControlChange} />
+                    <div className="space-y-2 pt-4 border-t border-slate-200">
+                        <label htmlFor="professional" className="block text-sm font-medium text-slate-600 mb-1">Profesional</label>
+                        <input
+                            type="text"
+                            id="professional"
+                            name="professional"
+                            value={controlInfo.professional}
+                            onChange={(e) => handleControlChange('professional', e.target.value)}
+                            className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        />
+                    </div>
                     <ControlInfoForm controlInfo={controlInfo} onChange={handleControlChange} />
                 </div>
 
@@ -340,15 +351,24 @@ const App: React.FC = () => {
                        controlInfo={controlInfo}
                        onEditMedication={(id) => {
                          const med = medications.find(m => m.id === id);
-                         if (med) setEditingMedication(med);
+                         if (med) {
+                           setActiveTab('oral');
+                           setEditingMedication(med);
+                         }
                        }}
                        onEditInjectable={(id) => {
                          const inj = injectables.find(i => i.id === id);
-                         if (inj) setEditingInjectable(inj);
+                         if (inj) {
+                           setActiveTab('injectable');
+                           setEditingInjectable(inj);
+                         }
                        }}
                        onEditInhaler={(id) => {
                          const inh = inhalers.find(i => i.id === id);
-                         if (inh) setEditingInhaler(inh);
+                         if (inh) {
+                           setActiveTab('inhaled');
+                           setEditingInhaler(inh);
+                         }
                        }}
                      />
                    </div>

--- a/App.tsx
+++ b/App.tsx
@@ -1,9 +1,10 @@
 
 import React, { useState, useRef, useCallback } from 'react';
-import { Patient, Medication, Injectable, ControlInfo, ExamOptions } from './types';
+import { Patient, Medication, Injectable, ControlInfo, ExamOptions, Inhaler } from './types';
 import PatientInfoForm from './components/PatientInfoForm';
 import MedicationForm from './components/MedicationForm';
 import InjectableForm from './components/InjectableForm';
+import InhalerForm from './components/InhalerForm';
 import SchedulePreview from './components/SchedulePreview';
 import TrashIcon from './components/icons/TrashIcon';
 import ControlInfoForm from './components/ControlInfoForm';
@@ -38,9 +39,12 @@ const App: React.FC = () => {
     const [patient, setPatient] = useState<Patient>({ name: '', rut: '', date: today });
     const [medications, setMedications] = useState<Medication[]>([]);
     const [injectables, setInjectables] = useState<Injectable[]>([]);
+    const [inhalers, setInhalers] = useState<Inhaler[]>([]);
     const [controlInfo, setControlInfo] = useState<ControlInfo>(initialControlInfo);
     const [editingMedication, setEditingMedication] = useState<Medication | null>(null);
     const [editingInjectable, setEditingInjectable] = useState<Injectable | null>(null);
+    const [editingInhaler, setEditingInhaler] = useState<Inhaler | null>(null);
+    const [activeTab, setActiveTab] = useState<'oral' | 'injectable' | 'inhaled'>('oral');
 
 
     const previewRef = useRef<HTMLDivElement>(null);
@@ -74,6 +78,18 @@ const App: React.FC = () => {
         setInjectables(prev => prev.filter(ins => ins.id !== id));
     }, []);
 
+    const addInhaler = useCallback((inh: Omit<Inhaler, 'id'>) => {
+        setInhalers(prev => [...prev, { ...inh, id: Date.now() }]);
+    }, []);
+
+    const updateInhaler = useCallback((id: number, inh: Omit<Inhaler, 'id'>) => {
+        setInhalers(prev => prev.map(i => i.id === id ? { ...i, ...inh } : i));
+    }, []);
+
+    const removeInhaler = useCallback((id: number) => {
+        setInhalers(prev => prev.filter(i => i.id !== id));
+    }, []);
+
     const handleControlChange = useCallback((field: keyof ControlInfo, value: string | boolean | ExamOptions) => {
         setControlInfo(prev => ({...prev, [field]: value}));
     }, []);
@@ -85,7 +101,7 @@ const App: React.FC = () => {
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const handleExportList = () => {
-        const data = { medications, injectables };
+        const data = { medications, injectables, inhalers };
         const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
@@ -104,6 +120,7 @@ const App: React.FC = () => {
                 const data = JSON.parse(ev.target?.result as string);
                 setMedications(data.medications || []);
                 setInjectables(data.injectables || []);
+                setInhalers(data.inhalers || []);
             } catch (err) {
                 console.error('Error al importar lista', err);
             }
@@ -151,88 +168,165 @@ const App: React.FC = () => {
                 {/* Control Panel */}
                 <div className="bg-white p-6 rounded-xl shadow-lg space-y-8">
                     <PatientInfoForm patient={patient} onChange={handlePatientChange} />
-                    <MedicationForm onAddMedication={addMedication} onUpdateMedication={updateMedication} editingMedication={editingMedication} onCancelEdit={() => setEditingMedication(null)} />
-                    <InjectableForm onAddInjectable={addInjectable} onUpdateInjectable={updateInjectable} editingInjectable={editingInjectable} onCancelEdit={() => setEditingInjectable(null)} />
+                    <div>
+                        <div className="flex border-b">
+                            <button
+                                className={`flex-1 py-2 text-sm font-semibold ${activeTab === 'oral' ? 'border-b-2 border-blue-500' : ''}`}
+                                onClick={() => setActiveTab('oral')}
+                                type="button"
+                            >
+                                Fármacos orales
+                            </button>
+                            <button
+                                className={`flex-1 py-2 text-sm font-semibold ${activeTab === 'injectable' ? 'border-b-2 border-blue-500' : ''}`}
+                                onClick={() => setActiveTab('injectable')}
+                                type="button"
+                            >
+                                Fármacos inyectables
+                            </button>
+                            <button
+                                className={`flex-1 py-2 text-sm font-semibold ${activeTab === 'inhaled' ? 'border-b-2 border-blue-500' : ''}`}
+                                onClick={() => setActiveTab('inhaled')}
+                                type="button"
+                            >
+                                Fármacos inhalados
+                            </button>
+                        </div>
+                        <div className="pt-4 space-y-4">
+                            {activeTab === 'oral' && (
+                                <>
+                                    <MedicationForm onAddMedication={addMedication} onUpdateMedication={updateMedication} editingMedication={editingMedication} onCancelEdit={() => setEditingMedication(null)} />
+                                    {medications.length > 0 && (
+                                        <div className="space-y-4">
+                                            <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Medicamentos Añadidos</h3>
+                                            <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
+                                                {medications.map((med) => (
+                                                    <li key={med.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
+                                                        <div>
+                                                            <p className="font-bold text-blue-600 flex items-center gap-1">
+                                                                {med.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
+                                                                {med.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
+                                                                {med.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
+                                                                {med.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
+                                                                {med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span>
+                                                            </p>
+                                                            <p className="text-sm text-slate-500">{`${med.dose} comprimido(s) - ${med.frequency}`}</p>
+                                                            {med.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {med.notes}</p>}
+                                                        </div>
+                                                        <div className="flex gap-2">
+                                                            <button
+                                                                onClick={() => setEditingMedication(med)}
+                                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
+                                                                aria-label="Editar medicamento"
+                                                            >
+                                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
+                                                            </button>
+                                                            <button
+                                                                onClick={() => removeMedication(med.id)}
+                                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
+                                                                aria-label="Eliminar medicamento"
+                                                            >
+                                                                <TrashIcon className="w-5 h-5" />
+                                                            </button>
+                                                        </div>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                            {activeTab === 'injectable' && (
+                                <>
+                                    <InjectableForm onAddInjectable={addInjectable} onUpdateInjectable={updateInjectable} editingInjectable={editingInjectable} onCancelEdit={() => setEditingInjectable(null)} />
+                                    {injectables.length > 0 && (
+                                        <div className="space-y-4">
+                                            <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Tratamientos Inyectables Añadidos</h3>
+                                            <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
+                                                {injectables.map((ins) => (
+                                                    <li key={ins.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
+                                                        <div>
+                                                            <p className="font-bold text-teal-600 flex items-center gap-1">
+                                                                {ins.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
+                                                                {ins.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
+                                                                {ins.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
+                                                                {ins.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
+                                                                {ins.type}
+                                                            </p>
+                                                            <p className="text-sm text-slate-500">{`${ins.dose} - ${ins.schedule} a las ${ins.time}`}</p>
+                                                            {ins.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {ins.notes}</p>}
+                                                        </div>
+                                                        <div className="flex gap-2">
+                                                            <button
+                                                                onClick={() => setEditingInjectable(ins)}
+                                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
+                                                                aria-label="Editar inyectable"
+                                                            >
+                                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
+                                                            </button>
+                                                            <button
+                                                                onClick={() => removeInjectable(ins.id)}
+                                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
+                                                                aria-label="Eliminar inyectable"
+                                                            >
+                                                                <TrashIcon className="w-5 h-5" />
+                                                            </button>
+                                                        </div>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                            {activeTab === 'inhaled' && (
+                                <>
+                                    <InhalerForm onAddInhaler={addInhaler} onUpdateInhaler={updateInhaler} editingInhaler={editingInhaler} onCancelEdit={() => setEditingInhaler(null)} />
+                                    {inhalers.length > 0 && (
+                                        <div className="space-y-4">
+                                            <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Inhaladores Añadidos</h3>
+                                            <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
+                                                {inhalers.map((inh) => (
+                                                    <li key={inh.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
+                                                        <div>
+                                                            <p className="font-bold text-purple-600 flex items-center gap-1">
+                                                                {inh.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
+                                                                {inh.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
+                                                                {inh.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
+                                                                {inh.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
+                                                                {inh.name} <span className="text-slate-600 font-normal">{inh.presentacion}</span>
+                                                            </p>
+                                                            <p className="text-sm text-slate-500">{`${inh.dose} puff(s) - cada ${inh.frequencyHours} h`}</p>
+                                                            {inh.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {inh.notes}</p>}
+                                                        </div>
+                                                        <div className="flex gap-2">
+                                                            <button
+                                                                onClick={() => setEditingInhaler(inh)}
+                                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
+                                                                aria-label="Editar inhalador"
+                                                            >
+                                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
+                                                            </button>
+                                                            <button
+                                                                onClick={() => removeInhaler(inh.id)}
+                                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
+                                                                aria-label="Eliminar inhalador"
+                                                            >
+                                                                <TrashIcon className="w-5 h-5" />
+                                                            </button>
+                                                        </div>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    </div>
+
                     <SuspensionSection controlInfo={controlInfo} onChange={handleControlChange} />
                     <ControlInfoForm controlInfo={controlInfo} onChange={handleControlChange} />
-                    
-                    {medications.length > 0 && (
-                        <div className="space-y-4">
-                            <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Medicamentos Añadidos</h3>
-                            <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
-                                {medications.map((med) => (
-                                    <li key={med.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
-                                        <div>
-                                            <p className="font-bold text-blue-600 flex items-center gap-1">
-                                                {med.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
-                                                {med.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
-                                                {med.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
-                                                {med.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
-                                                {med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span>
-                                            </p>
-                        <p className="text-sm text-slate-500">{`${med.dose} comprimido(s) - ${med.frequency}`}</p>
-                                            {med.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {med.notes}</p>}
-                                        </div>
-                                        <div className="flex gap-2">
-                                            <button
-                                                onClick={() => setEditingMedication(med)}
-                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
-                                                aria-label="Editar medicamento"
-                                            >
-                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
-                                            </button>
-                                            <button
-                                                onClick={() => removeMedication(med.id)}
-                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
-                                                aria-label="Eliminar medicamento"
-                                            >
-                                                <TrashIcon className="w-5 h-5" />
-                                            </button>
-                                        </div>
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    )}
-
-                    {injectables.length > 0 && (
-                        <div className="space-y-4">
-                            <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Tratamientos Inyectables Añadidos</h3>
-                            <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
-                                {injectables.map((ins) => (
-                                    <li key={ins.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
-                                        <div>
-                                            <p className="font-bold text-teal-600 flex items-center gap-1">
-                                                {ins.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
-                                                {ins.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
-                                                {ins.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
-                                                {ins.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
-                                                {ins.type}
-                                            </p>
-                                            <p className="text-sm text-slate-500">{`${ins.dose} - ${ins.schedule} a las ${ins.time}`}</p>
-                                            {ins.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {ins.notes}</p>}
-                                        </div>
-                                        <div className="flex gap-2">
-                                            <button
-                                                onClick={() => setEditingInjectable(ins)}
-                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
-                                                aria-label="Editar inyectable"
-                                            >
-                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
-                                            </button>
-                                            <button
-                                                onClick={() => removeInjectable(ins.id)}
-                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
-                                                aria-label="Eliminar inyectable"
-                                            >
-                                                <TrashIcon className="w-5 h-5" />
-                                            </button>
-                                        </div>
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    )}
                 </div>
 
                 {/* Preview Panel */}
@@ -242,6 +336,7 @@ const App: React.FC = () => {
                        patient={patient}
                        medications={medications}
                        injectables={injectables}
+                       inhalers={inhalers}
                        controlInfo={controlInfo}
                        onEditMedication={(id) => {
                          const med = medications.find(m => m.id === id);
@@ -250,6 +345,10 @@ const App: React.FC = () => {
                        onEditInjectable={(id) => {
                          const inj = injectables.find(i => i.id === id);
                          if (inj) setEditingInjectable(inj);
+                       }}
+                       onEditInhaler={(id) => {
+                         const inh = inhalers.find(i => i.id === id);
+                         if (inh) setEditingInhaler(inh);
                        }}
                      />
                    </div>

--- a/App.tsx
+++ b/App.tsx
@@ -238,7 +238,20 @@ const App: React.FC = () => {
                 {/* Preview Panel */}
                 <div className="bg-slate-200 p-4 sm:p-6 rounded-xl shadow-inner flex items-start justify-center overflow-x-auto">
                    <div ref={previewRef} className="w-full">
-                     <SchedulePreview patient={patient} medications={medications} injectables={injectables} controlInfo={controlInfo} />
+                     <SchedulePreview
+                       patient={patient}
+                       medications={medications}
+                       injectables={injectables}
+                       controlInfo={controlInfo}
+                       onEditMedication={(id) => {
+                         const med = medications.find(m => m.id === id);
+                         if (med) setEditingMedication(med);
+                       }}
+                       onEditInjectable={(id) => {
+                         const inj = injectables.find(i => i.id === id);
+                         if (inj) setEditingInjectable(inj);
+                       }}
+                     />
                    </div>
                 </div>
             </main>

--- a/components/ControlInfoForm.tsx
+++ b/components/ControlInfoForm.tsx
@@ -81,17 +81,6 @@ const ControlInfoForm: React.FC<ControlInfoFormProps> = ({ controlInfo, onChange
                         </div>
                     </div>
                     <div>
-                        <label htmlFor="professional" className="block text-sm font-medium text-slate-600 mb-1">Profesional</label>
-                        <input
-                            type="text"
-                            id="professional"
-                            name="professional"
-                            value={controlInfo.professional}
-                            onChange={(e) => onChange('professional', e.target.value)}
-                            className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                        />
-                    </div>
-                    <div>
                         <label htmlFor="withExams" className="block text-sm font-medium text-slate-600 mb-1">Con Exámenes</label>
                         <select
                             id="withExams"

--- a/components/DoseVisualizer.tsx
+++ b/components/DoseVisualizer.tsx
@@ -14,8 +14,9 @@ const DoseVisualizer: React.FC<DoseVisualizerProps> = ({ dose, className }) => {
     
     // Renderiza múltiples cápsulas para dosis mayores a 1
     const renderMultiplePills = (count: number) => {
+        const spacingClass = count >= 3 ? '-space-x-2' : 'space-x-2';
         return (
-            <div className="flex items-center justify-center space-x-2">
+            <div className={`flex items-center justify-center ${spacingClass}`}>
                 {Array.from({ length: count }).map((_, i) => (
                     <PillIcon key={i} className="w-10 h-10" />
                 ))}

--- a/components/InhalerForm.tsx
+++ b/components/InhalerForm.tsx
@@ -1,20 +1,19 @@
-
 import React, { useState, useEffect } from 'react';
-import { Medication, Frequency, Dose } from '../types';
+import { Inhaler } from '../types';
 import PlusIcon from './icons/PlusIcon';
 
-interface MedicationFormProps {
-    onAddMedication: (med: Omit<Medication, 'id'>) => void;
-    onUpdateMedication?: (id: number, med: Omit<Medication, 'id'>) => void;
-    editingMedication?: Medication | null;
+interface InhalerFormProps {
+    onAddInhaler: (inh: Omit<Inhaler, 'id'>) => void;
+    onUpdateInhaler?: (id: number, inh: Omit<Inhaler, 'id'>) => void;
+    editingInhaler?: Inhaler | null;
     onCancelEdit?: () => void;
 }
 
-const initialMedState: Omit<Medication, 'id'> = {
+const initialState: Omit<Inhaler, 'id'> = {
     name: '',
     presentacion: '',
-    dose: Dose.ONE,
-    frequency: Frequency.EVERY_12H,
+    dose: 2,
+    frequencyHours: 8,
     notes: '',
     isNewMedication: false,
     doseIncreased: false,
@@ -22,98 +21,99 @@ const initialMedState: Omit<Medication, 'id'> = {
     requiresPurchase: false,
 };
 
-const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpdateMedication, editingMedication, onCancelEdit }) => {
-    const [medication, setMedication] = useState(initialMedState);
+const InhalerForm: React.FC<InhalerFormProps> = ({ onAddInhaler, onUpdateInhaler, editingInhaler, onCancelEdit }) => {
+    const [inhaler, setInhaler] = useState(initialState);
 
     useEffect(() => {
-        if (editingMedication) {
-            const { id, ...rest } = editingMedication;
-            setMedication(rest);
+        if (editingInhaler) {
+            const { id, ...rest } = editingInhaler;
+            setInhaler(rest);
         } else {
-            setMedication(initialMedState);
+            setInhaler(initialState);
         }
-    }, [editingMedication]);
+    }, [editingInhaler]);
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, type } = e.target;
-        const value = type === 'checkbox' ? (e.target as HTMLInputElement).checked : e.target.value;
-        setMedication(prev => ({ ...prev, [name]: value }));
+        let value: string | number | boolean = e.target.value;
+        if (type === 'checkbox') {
+            value = (e.target as HTMLInputElement).checked;
+        } else if (type === 'number') {
+            value = Number(value);
+        }
+        setInhaler(prev => ({ ...prev, [name]: value }));
     };
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
-        if (medication.name && medication.presentacion) {
-            if (editingMedication) {
-                onUpdateMedication && onUpdateMedication(editingMedication.id, medication);
+        if (inhaler.name && inhaler.presentacion) {
+            if (editingInhaler) {
+                onUpdateInhaler && onUpdateInhaler(editingInhaler.id, inhaler);
                 onCancelEdit && onCancelEdit();
             } else {
-                onAddMedication(medication);
+                onAddInhaler(inhaler);
             }
-            setMedication(initialMedState);
+            setInhaler(initialState);
         }
     };
 
     return (
         <form onSubmit={handleSubmit} className="space-y-2 pt-2 border-t border-slate-200">
             <h2 className="text-2xl font-bold text-slate-800 border-b-2 border-blue-200 pb-2">
-                {editingMedication ? 'Editar Fármaco Oral' : 'Añadir Fármaco Oral'}
+                {editingInhaler ? 'Editar Inhalador' : 'Añadir Inhalador'}
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
-                    <label htmlFor="medName" className="block text-sm font-medium text-slate-600 mb-1">Nombre del Medicamento</label>
+                    <label htmlFor="inhName" className="block text-sm font-medium text-slate-600 mb-1">Nombre del Medicamento</label>
                     <input
                         type="text"
-                        id="medName"
+                        id="inhName"
                         name="name"
-                        value={medication.name}
+                        value={inhaler.name}
                         onChange={handleChange}
-                        placeholder="Ej: Losartán"
                         className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
                 <div>
-                    <label htmlFor="presentacion" className="block text-sm font-medium text-slate-600 mb-1">Presentación</label>
+                    <label htmlFor="inhPres" className="block text-sm font-medium text-slate-600 mb-1">Presentación</label>
                     <input
                         type="text"
-                        id="presentacion"
+                        id="inhPres"
                         name="presentacion"
-                        value={medication.presentacion}
+                        value={inhaler.presentacion}
                         onChange={handleChange}
-                        placeholder="Ej: 50mg"
                         className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
             </div>
-             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
-                    <label htmlFor="dose" className="block text-sm font-medium text-slate-600 mb-1">Dosis (comprimidos)</label>
-                    <select
-                        id="dose"
+                    <label htmlFor="inhDose" className="block text-sm font-medium text-slate-600 mb-1">Dosis (puff)</label>
+                    <input
+                        type="number"
+                        id="inhDose"
                         name="dose"
-                        value={medication.dose}
+                        value={inhaler.dose}
                         onChange={handleChange}
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
-                    >
-                        {Object.values(Dose).map(d => (
-                            <option key={d} value={d}>{d}</option>
-                        ))}
-                    </select>
+                        min={0}
+                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        required
+                    />
                 </div>
                 <div>
-                    <label htmlFor="frequency" className="block text-sm font-medium text-slate-600 mb-1">Frecuencia</label>
-                    <select
-                        id="frequency"
-                        name="frequency"
-                        value={medication.frequency}
+                    <label htmlFor="inhFreq" className="block text-sm font-medium text-slate-600 mb-1">Frecuencia (cada X horas)</label>
+                    <input
+                        type="number"
+                        id="inhFreq"
+                        name="frequencyHours"
+                        value={inhaler.frequencyHours}
                         onChange={handleChange}
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
-                    >
-                        {Object.values(Frequency).map(freq => (
-                            <option key={freq} value={freq}>{freq}</option>
-                        ))}
-                    </select>
+                        min={0}
+                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        required
+                    />
                 </div>
             </div>
             <div className="grid grid-cols-2 gap-2">
@@ -121,7 +121,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     <input
                         type="checkbox"
                         name="isNewMedication"
-                        checked={medication.isNewMedication}
+                        checked={inhaler.isNewMedication}
                         onChange={handleChange}
                         className="mr-2"
                     />
@@ -131,7 +131,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     <input
                         type="checkbox"
                         name="doseIncreased"
-                        checked={medication.doseIncreased}
+                        checked={inhaler.doseIncreased}
                         onChange={handleChange}
                         className="mr-2"
                     />
@@ -141,7 +141,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     <input
                         type="checkbox"
                         name="doseDecreased"
-                        checked={medication.doseDecreased}
+                        checked={inhaler.doseDecreased}
                         onChange={handleChange}
                         className="mr-2"
                     />
@@ -151,7 +151,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     <input
                         type="checkbox"
                         name="requiresPurchase"
-                        checked={medication.requiresPurchase}
+                        checked={inhaler.requiresPurchase}
                         onChange={handleChange}
                         className="mr-2"
                     />
@@ -159,13 +159,12 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                 </label>
             </div>
             <div>
-                <label htmlFor="notes" className="block text-sm font-medium text-slate-600 mb-1">Notas (Opcional)</label>
+                <label htmlFor="inhNotes" className="block text-sm font-medium text-slate-600 mb-1">Notas (Opcional)</label>
                 <textarea
-                    id="notes"
+                    id="inhNotes"
                     name="notes"
-                    value={medication.notes}
+                    value={inhaler.notes}
                     onChange={handleChange}
-                    placeholder="Ej: Tomar con abundante agua"
                     rows={2}
                     className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                 />
@@ -176,9 +175,9 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     className="flex-1 bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center justify-center gap-2"
                 >
                     <PlusIcon className="h-5 w-5" />
-                    {editingMedication ? 'Actualizar Fármaco Oral' : 'Añadir Fármaco Oral'}
+                    {editingInhaler ? 'Actualizar Inhalador' : 'Añadir Inhalador'}
                 </button>
-                {editingMedication && (
+                {editingInhaler && (
                     <button
                         type="button"
                         onClick={onCancelEdit}
@@ -192,4 +191,4 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
     );
 };
 
-export default MedicationForm;
+export default InhalerForm;

--- a/components/InjectableForm.tsx
+++ b/components/InjectableForm.tsx
@@ -88,7 +88,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
     return (
         <form onSubmit={handleSubmit} className="space-y-4 pt-4 border-t border-slate-200">
             <h2 className="text-2xl font-bold text-slate-800 border-b-2 border-blue-200 pb-2">
-                {editingInjectable ? 'Editar Tratamiento Inyectable' : 'Añadir Tratamiento Inyectable (Insulinas, Agonistas GLP-1)'}
+                {editingInjectable ? 'Editar Fármaco Inyectable' : 'Añadir Fármaco Inyectable'}
             </h2>
 
             <div>
@@ -262,7 +262,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                     className="flex-1 bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center justify-center gap-2"
                 >
                     <PlusIcon className="h-5 w-5" />
-                    {editingInjectable ? 'Actualizar Tratamiento' : 'Añadir Tratamiento'}
+                    {editingInjectable ? 'Actualizar Inyectable' : 'Añadir Inyectable'}
                 </button>
                 {editingInjectable && (
                     <button

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Patient, Medication, Frequency, Dose, Injectable, InjectableSchedule, InjectableType, ControlInfo } from '../types';
+import { Patient, Medication, Frequency, Dose, Injectable, InjectableSchedule, InjectableType, ControlInfo, Inhaler } from '../types';
 import DoseVisualizer from './DoseVisualizer';
 import MoonIcon from './icons/MoonIcon';
 import SunIcon from './icons/SunIcon';
@@ -15,12 +15,14 @@ interface SchedulePreviewProps {
     patient: Patient;
     medications: Medication[];
     injectables: Injectable[];
+    inhalers: Inhaler[];
     controlInfo: ControlInfo;
     onEditMedication?: (id: number) => void;
     onEditInjectable?: (id: number) => void;
+    onEditInhaler?: (id: number) => void;
 }
 
-const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, controlInfo, onEditMedication, onEditInjectable }) => {
+const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, inhalers, controlInfo, onEditMedication, onEditInjectable, onEditInhaler }) => {
 
     const shouldShowDose = (freq: Frequency, time: 'morning' | 'afternoon' | 'night'): boolean => {
         switch (time) {
@@ -106,6 +108,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
 
     const medicationItems = medications.map(med => ({ ...med, itemType: 'medication' as const }));
 
+    const inhalerItems = inhalers.map(inh => ({ ...inh, itemType: 'inhaler' as const }));
+
     const injectableItems = Array.from(groupedInjectables.entries()).map(([type, data]) => ({
         id: type,
         editId: data.mañana[0]?.id ?? data.noche[0]?.id,
@@ -118,7 +122,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
         requiresPurchase: data.requiresPurchase,
     }));
 
-    const allItems = [...medicationItems, ...injectableItems];
+    const allItems = [...medicationItems, ...inhalerItems, ...injectableItems];
 
     const formattedControlDate = controlInfo.date ? new Date(`${controlInfo.date}T${controlInfo.time || '00:00'}`).toLocaleString('es-CL', { dateStyle: 'short', timeStyle: 'short' }) : '';
 
@@ -168,6 +172,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                 </th>
                                 <th className="p-2 text-center font-semibold text-sm w-1/6">
                                     <div className="flex flex-col items-center justify-center gap-0.5">
+                                        <SunIcon className="w-5 h-5" />
                                         <span>Tarde</span>
                                     </div>
                                 </th>
@@ -185,9 +190,9 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                 if (item.itemType === 'medication') {
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
-                                            <td className="p-2 text-center align-top">{index + 1}</td>
-                                            <td className="p-2 align-top text-center">
-                                                <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
+                                            <td className="p-2 text-center align-top">
+                                                <div className="flex items-center justify-center gap-1">
+                                                    <span>{index + 1}</span>
                                                     {onEditMedication && (
                                                         <button
                                                             onClick={() => onEditMedication(item.id)}
@@ -198,6 +203,10 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                             <EditIcon className="w-4 h-4" />
                                                         </button>
                                                     )}
+                                                </div>
+                                            </td>
+                                            <td className="p-2 align-top text-center">
+                                                <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
                                                     {item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
@@ -237,6 +246,68 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                             </td>
                                         </tr>
                                     );
+                                } else if (item.itemType === 'inhaler') {
+                                    const showMorning = item.frequencyHours === 8 || item.frequencyHours === 12;
+                                    const showAfternoon = item.frequencyHours === 8;
+                                    const showNight = item.frequencyHours === 8 || item.frequencyHours === 12;
+                                    return (
+                                        <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
+                                            <td className="p-2 text-center align-top">
+                                                <div className="flex items-center justify-center gap-1">
+                                                    <span>{index + 1}</span>
+                                                    {onEditInhaler && (
+                                                        <button
+                                                            onClick={() => onEditInhaler(item.id)}
+                                                            className="text-blue-500 hover:text-blue-700 print:hidden"
+                                                            contentEditable={false}
+                                                            aria-label="Editar inhalador"
+                                                        >
+                                                            <EditIcon className="w-4 h-4" />
+                                                        </button>
+                                                    )}
+                                                </div>
+                                            </td>
+                                            <td className="p-2 align-top text-center">
+                                                <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
+                                                    {item.isNewMedication && (
+                                                        <span contentEditable={false}>
+                                                            <StarIcon className="inline w-4 h-4 text-yellow-500" />
+                                                        </span>
+                                                    )}
+                                                    {item.doseIncreased && (
+                                                        <span contentEditable={false}>
+                                                            <ArrowUpIcon className="inline w-4 h-4" />
+                                                        </span>
+                                                    )}
+                                                    {item.doseDecreased && (
+                                                        <span contentEditable={false}>
+                                                            <ArrowDownIcon className="inline w-4 h-4" />
+                                                        </span>
+                                                    )}
+                                                    {item.requiresPurchase && (
+                                                        <span contentEditable={false}>
+                                                            <MoneyIcon className="inline w-4 h-4 text-green-600" />
+                                                        </span>
+                                                    )}
+                                                    {item.name}
+                                                </p>
+                                                <p className="text-sm text-slate-600">{item.presentacion}</p>
+                                                <p className="text-xs text-slate-500 italic">{`${item.dose} puff - cada ${item.frequencyHours} h`}</p>
+                                            </td>
+                                            <td className="p-2 text-center align-middle" contentEditable={false}>
+                                                {showMorning && <span className="font-bold">{item.dose}</span>}
+                                            </td>
+                                            <td className="p-2 text-center align-middle" contentEditable={false}>
+                                                {showAfternoon && <span className="font-bold">{item.dose}</span>}
+                                            </td>
+                                            <td className="p-2 text-center align-middle" contentEditable={false}>
+                                                {showNight && <span className="font-bold">{item.dose}</span>}
+                                            </td>
+                                            <td className="p-2 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
+                                                {item.notes || ''}
+                                            </td>
+                                        </tr>
+                                    );
                                 } else { // item.itemType === 'injectable'
                                     const allNotes = [...item.schedules.mañana, ...item.schedules.noche]
                                         .map(ins => ins.notes)
@@ -244,9 +315,9 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                         .join('\n');
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
-                                            <td className="p-2 text-center align-top">{index + 1}</td>
-                                            <td className="p-2 align-top text-center">
-                                                <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
+                                            <td className="p-2 text-center align-top">
+                                                <div className="flex items-center justify-center gap-1">
+                                                    <span>{index + 1}</span>
                                                     {onEditInjectable && item.editId != null && (
                                                         <button
                                                             onClick={() => onEditInjectable(item.editId!)}
@@ -257,6 +328,10 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                             <EditIcon className="w-4 h-4" />
                                                         </button>
                                                     )}
+                                                </div>
+                                            </td>
+                                            <td className="p-2 align-top text-center">
+                                                <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
                                                     {item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
@@ -307,7 +382,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                             }) : (
                                 <tr>
                                     <td colSpan={6} className="text-center p-4 text-slate-500">
-                                        <p>Añada un medicamento o tratamiento inyectable para verlo aquí.</p>
+                                        <p>Añada un medicamento, inhalador o tratamiento inyectable para verlo aquí.</p>
                                     </td>
                                 </tr>
                             )}

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -295,13 +295,13 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                 <p className="text-xs text-slate-500 italic">{`${item.dose} puff - cada ${item.frequencyHours} h`}</p>
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                {showMorning && <span className="font-bold">{item.dose}</span>}
+                                                {showMorning && <span className="font-bold">{`${item.dose} puff`}</span>}
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                {showAfternoon && <span className="font-bold">{item.dose}</span>}
+                                                {showAfternoon && <span className="font-bold">{`${item.dose} puff`}</span>}
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                {showNight && <span className="font-bold">{item.dose}</span>}
+                                                {showNight && <span className="font-bold">{`${item.dose} puff`}</span>}
                                             </td>
                                             <td className="p-2 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
                                                 {item.notes || ''}
@@ -439,8 +439,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                 </section>
             )}
 
-            <section className="mt-16 pt-8 text-center">
-                <div className="grid grid-cols-2 gap-8">
+            <section className="mt-12 pt-6 text-center">
+                <div className="grid grid-cols-2 gap-4">
                     <div className="flex flex-col items-center">
                         <div className="w-4/5 h-12 border-b-2 border-slate-400"></div>
                         <p className="mt-2 text-sm font-semibold text-slate-600">{controlInfo.professional || 'Nombre Profesional'}</p>

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -8,15 +8,19 @@ import StarIcon from './icons/StarIcon';
 import MoneyIcon from "./icons/MoneyIcon";
 import ArrowUpIcon from './icons/ArrowUpIcon';
 import ArrowDownIcon from './icons/ArrowDownIcon';
+import EditIcon from './icons/EditIcon';
+import RedCrossIcon from './icons/RedCrossIcon';
 
 interface SchedulePreviewProps {
     patient: Patient;
     medications: Medication[];
     injectables: Injectable[];
     controlInfo: ControlInfo;
+    onEditMedication?: (id: number) => void;
+    onEditInjectable?: (id: number) => void;
 }
 
-const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, controlInfo }) => {
+const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, controlInfo, onEditMedication, onEditInjectable }) => {
 
     const shouldShowDose = (freq: Frequency, time: 'morning' | 'afternoon' | 'night'): boolean => {
         switch (time) {
@@ -104,6 +108,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
 
     const injectableItems = Array.from(groupedInjectables.entries()).map(([type, data]) => ({
         id: type,
+        editId: data.mañana[0]?.id ?? data.noche[0]?.id,
         itemType: 'injectable' as const,
         type,
         schedules: { mañana: data.mañana, noche: data.noche },
@@ -120,7 +125,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
     return (
         <div id="schedule-preview" className="bg-white p-8 rounded-lg shadow-xl w-full max-w-4xl mx-auto border border-slate-200">
             <header className="text-center mb-8 border-b-2 pb-4 border-slate-200">
-                <h1 className="text-3xl font-extrabold text-blue-700">Cartola de Medicamentos</h1>
+                <h1 className="text-2xl font-extrabold text-blue-700">Cartola de Medicamentos</h1>
             </header>
             
             <section className="mb-8 grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
@@ -183,6 +188,16 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                             <td className="p-2 text-center align-top">{index + 1}</td>
                                             <td className="p-2 align-top text-center">
                                                 <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
+                                                    {onEditMedication && (
+                                                        <button
+                                                            onClick={() => onEditMedication(item.id)}
+                                                            className="text-blue-500 hover:text-blue-700 print:hidden"
+                                                            contentEditable={false}
+                                                            aria-label="Editar medicamento"
+                                                        >
+                                                            <EditIcon className="w-4 h-4" />
+                                                        </button>
+                                                    )}
                                                     {item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
@@ -230,8 +245,18 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
                                             <td className="p-2 text-center align-top">{index + 1}</td>
-                                            <td className="p-2 align-top">
-                                                <p className="font-bold text-md text-slate-800 flex items-center gap-1">
+                                            <td className="p-2 align-top text-center">
+                                                <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
+                                                    {onEditInjectable && item.editId != null && (
+                                                        <button
+                                                            onClick={() => onEditInjectable(item.editId!)}
+                                                            className="text-blue-500 hover:text-blue-700 print:hidden"
+                                                            contentEditable={false}
+                                                            aria-label="Editar inyectable"
+                                                        >
+                                                            <EditIcon className="w-4 h-4" />
+                                                        </button>
+                                                    )}
                                                     {item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
@@ -293,7 +318,10 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
 
             {controlInfo.suspendEnabled && controlInfo.suspendText && (
                 <section className="mb-8">
-                    <h3 className="text-lg font-bold text-black mb-2 text-center">Suspender los siguientes medicamentos</h3>
+                    <h3 className="text-base font-bold text-black mb-2 text-center flex items-center justify-center gap-1">
+                        <RedCrossIcon className="w-4 h-4 text-red-600" />
+                        Suspender los siguientes medicamentos
+                    </h3>
                     <div className="p-3 border border-black rounded text-black text-sm whitespace-pre-wrap">{controlInfo.suspendText}</div>
                 </section>
             )}

--- a/components/SuspensionSection.tsx
+++ b/components/SuspensionSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ControlInfo } from '../types';
+import RedCrossIcon from './icons/RedCrossIcon';
 
 interface SuspensionSectionProps {
   controlInfo: ControlInfo;
@@ -28,7 +29,8 @@ const SuspensionSection: React.FC<SuspensionSectionProps> = ({ controlInfo, onCh
     </div>
     {controlInfo.suspendEnabled && (
       <div>
-        <label className="block text-sm font-medium text-black mb-1">
+        <label className="block text-xs font-medium text-black mb-1 flex items-center gap-1">
+          <RedCrossIcon className="w-4 h-4" />
           Suspender los siguientes medicamentos
         </label>
         <textarea

--- a/components/icons/EditIcon.tsx
+++ b/components/icons/EditIcon.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const EditIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className || 'w-4 h-4'}
+  >
+    <path d="M15.232 5.232l3.536 3.536" />
+    <path d="M16.732 3.732a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" />
+  </svg>
+);
+
+export default EditIcon;

--- a/components/icons/RedCrossIcon.tsx
+++ b/components/icons/RedCrossIcon.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const RedCrossIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className || 'w-4 h-4 text-red-600'}
+  >
+    <path d="M10 4h4v6h6v4h-6v6h-4v-6H4v-4h6V4z" />
+  </svg>
+);
+
+export default RedCrossIcon;

--- a/types.ts
+++ b/types.ts
@@ -17,9 +17,9 @@ export enum Dose {
     ONE_AND_QUARTER = '1 + 1/4',
     ONE_AND_HALF = '1 + 1/2',
     ONE_AND_THREE_QUARTERS = '1 + 3/4',
-    TWO = '1 + 1',
-    THREE = '1 + 2',
-    FOUR = '1 + 3',
+    TWO = '2',
+    THREE = '3',
+    FOUR = '4',
 }
 
 export interface Medication {

--- a/types.ts
+++ b/types.ts
@@ -68,6 +68,19 @@ export interface Injectable {
     requiresPurchase?: boolean;
 }
 
+export interface Inhaler {
+    id: number;
+    name: string;
+    presentacion: string;
+    dose: number; // número de puff
+    frequencyHours: number; // cada X horas
+    notes?: string;
+    isNewMedication?: boolean;
+    doseIncreased?: boolean;
+    doseDecreased?: boolean;
+    requiresPurchase?: boolean;
+}
+
 export interface ExamOptions {
   sangre: boolean;
   orina: boolean;


### PR DESCRIPTION
## Summary
- Add edit icons for medications and injectables in schedule preview
- Adjust tablet dose labels to show 2, 3, and 4 with repeated pill graphics
- Add red cross and smaller text to suspension notice and align injectable list

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a7f3e47104832c87f677a6912fc074