### PR TITLE
Add free note section and update injectable options

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,7 +31,9 @@ const initialControlInfo: ControlInfo = {
     otrosText: '',
     note: '',
     suspendEnabled: false,
-    suspendText: ''
+    suspendText: '',
+    freeNoteEnabled: false,
+    freeNoteText: ''
 };
 
 const App: React.FC = () => {
@@ -118,7 +120,7 @@ const App: React.FC = () => {
         reader.onload = ev => {
             try {
                 const data = JSON.parse(ev.target?.result as string);
-                setMedications(data.medications || []);
+                setMedications((data.medications || []).map((m: Medication) => ({ description: 'comprimido/capsula', ...m })));
                 setInjectables(data.injectables || []);
                 setInhalers(data.inhalers || []);
             } catch (err) {
@@ -134,7 +136,7 @@ const App: React.FC = () => {
         <div className="min-h-screen font-sans text-slate-800">
             <header className="bg-white shadow-md">
                 <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-wrap gap-2 justify-between items-center">
-                    <h1 className="text-2xl font-bold text-blue-700">Generador de Cartola de Medicamentos</h1>
+                    <h1 className="text-2xl font-bold text-blue-700">Guía de Medicamentos</h1>
                     <div className="flex gap-2">
                         <button
                             onClick={handleExportList}

--- a/components/InjectableForm.tsx
+++ b/components/InjectableForm.tsx
@@ -30,7 +30,9 @@ const insulinTypes = [
     InjectableType.NPH,
     InjectableType.CRYSTALLINE,
     InjectableType.LANTUS,
+    InjectableType.TOUJEO,
     InjectableType.TRESIBA,
+    InjectableType.OTHER,
 ];
 
 const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpdateInjectable, editingInjectable, onCancelEdit }) => {

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -13,6 +13,7 @@ interface MedicationFormProps {
 const initialMedState: Omit<Medication, 'id'> = {
     name: '',
     presentacion: '',
+    description: 'comprimido/capsula',
     dose: Dose.ONE,
     frequency: Frequency.EVERY_12H,
     notes: '',
@@ -24,13 +25,18 @@ const initialMedState: Omit<Medication, 'id'> = {
 
 const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpdateMedication, editingMedication, onCancelEdit }) => {
     const [medication, setMedication] = useState(initialMedState);
+    const [descriptionOption, setDescriptionOption] = useState('comprimido/capsula');
 
     useEffect(() => {
         if (editingMedication) {
             const { id, ...rest } = editingMedication;
-            setMedication(rest);
+            const descOptions = ['comprimido/capsula', 'sobre', 'bicarbonato en polvo', 'gotas'];
+            const desc = rest.description || 'comprimido/capsula';
+            setMedication({ ...rest, description: desc });
+            setDescriptionOption(descOptions.includes(desc) ? desc : 'otro');
         } else {
             setMedication(initialMedState);
+            setDescriptionOption('comprimido/capsula');
         }
     }, [editingMedication]);
 
@@ -38,6 +44,12 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
         const { name, type } = e.target;
         const value = type === 'checkbox' ? (e.target as HTMLInputElement).checked : e.target.value;
         setMedication(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleDescriptionOptionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value;
+        setDescriptionOption(value);
+        setMedication(prev => ({ ...prev, description: value === 'otro' ? '' : value }));
     };
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -50,8 +62,11 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                 onAddMedication(medication);
             }
             setMedication(initialMedState);
+            setDescriptionOption('comprimido/capsula');
         }
     };
+
+    const displayDescription = descriptionOption === 'otro' ? (medication.description || 'unidad') : descriptionOption;
 
     return (
         <form onSubmit={handleSubmit} className="space-y-2 pt-2 border-t border-slate-200">
@@ -86,9 +101,35 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     />
                 </div>
             </div>
-             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div>
+                <label htmlFor="descriptionOption" className="block text-sm font-medium text-slate-600 mb-1">Descripción</label>
+                <select
+                    id="descriptionOption"
+                    value={descriptionOption}
+                    onChange={handleDescriptionOptionChange}
+                    className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                >
+                    <option value="comprimido/capsula">Comprimido/Cápsula</option>
+                    <option value="sobre">Sobre</option>
+                    <option value="bicarbonato en polvo">Bicarbonato en polvo</option>
+                    <option value="gotas">Gotas</option>
+                    <option value="otro">Otro</option>
+                </select>
+                {descriptionOption === 'otro' && (
+                    <input
+                        type="text"
+                        name="description"
+                        value={medication.description}
+                        onChange={handleChange}
+                        placeholder="Ingrese descripción"
+                        className="mt-2 w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        required
+                    />
+                )}
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
-                    <label htmlFor="dose" className="block text-sm font-medium text-slate-600 mb-1">Dosis (comprimidos)</label>
+                    <label htmlFor="dose" className="block text-sm font-medium text-slate-600 mb-1">{`Dosis (${displayDescription})`}</label>
                     <select
                         id="dose"
                         name="dose"

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -129,7 +129,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
     return (
         <div id="schedule-preview" className="bg-white p-8 rounded-lg shadow-xl w-full max-w-4xl mx-auto border border-slate-200">
             <header className="text-center mb-8 border-b-2 pb-4 border-slate-200">
-                <h1 className="text-2xl font-extrabold text-blue-700">Cartola de Medicamentos</h1>
+                <h1 className="text-2xl font-extrabold text-blue-700">Guía de Medicamentos</h1>
             </header>
             
             <section className="mb-8 grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
@@ -230,7 +230,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     {item.name}
                                                 </p>
                                                 <p className="text-sm text-slate-600">{item.presentacion}</p>
-                                                <p className="text-xs text-slate-500 italic">{`${item.dose} comp. - ${item.frequency}`}</p>
+                                                <p className="text-xs text-slate-500 italic">{`${item.dose} ${item.description || 'comprimido/capsula'} - ${item.frequency}`}</p>
                                             </td>
                                             <td className="p-2 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'morning')}>
                                                 {editableDoses[item.id]?.morning && <DoseVisualizer dose={editableDoses[item.id].morning} className="text-blue-600" />}
@@ -391,13 +391,23 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                 </div>
             </section>
 
-            {controlInfo.suspendEnabled && controlInfo.suspendText && (
+            {controlInfo.suspendEnabled && (
                 <section className="mb-8">
-                    <h3 className="text-base font-bold text-black mb-2 text-center flex items-center justify-center gap-1">
-                        <RedCrossIcon className="w-4 h-4 text-red-600" />
-                        Suspender los siguientes medicamentos
-                    </h3>
-                    <div className="p-3 border border-black rounded text-black text-sm whitespace-pre-wrap">{controlInfo.suspendText}</div>
+                    {controlInfo.suspendText && (
+                        <>
+                            <h3 className="text-base font-bold text-black mb-2 text-center flex items-center justify-center gap-1">
+                                <RedCrossIcon className="w-4 h-4 text-red-600" />
+                                Suspender los siguientes medicamentos
+                            </h3>
+                            <div className="p-3 border border-black rounded text-black text-sm whitespace-pre-wrap">{controlInfo.suspendText}</div>
+                        </>
+                    )}
+                    {controlInfo.freeNoteEnabled && controlInfo.freeNoteText && (
+                        <div className="mt-4">
+                            <h3 className="text-base font-bold text-black mb-2 text-center">Nota</h3>
+                            <div className="p-3 border border-black rounded text-black text-sm whitespace-pre-wrap">{controlInfo.freeNoteText}</div>
+                        </div>
+                    )}
                 </section>
             )}
 

--- a/components/SuspensionSection.tsx
+++ b/components/SuspensionSection.tsx
@@ -40,6 +40,35 @@ const SuspensionSection: React.FC<SuspensionSectionProps> = ({ controlInfo, onCh
           rows={2}
           className="w-full px-3 py-2 border border-black rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-black"
         />
+
+        <div className="mt-4">
+          <label htmlFor="freeNoteEnabled" className="block text-sm font-medium text-slate-600 mb-1">
+            Incluir sección nota libre
+          </label>
+          <select
+            id="freeNoteEnabled"
+            name="freeNoteEnabled"
+            value={controlInfo.freeNoteEnabled ? 'yes' : 'no'}
+            onChange={(e) => onChange('freeNoteEnabled', e.target.value === 'yes')}
+            className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+          >
+            <option value="no">No</option>
+            <option value="yes">Sí</option>
+          </select>
+        </div>
+
+        {controlInfo.freeNoteEnabled && (
+          <div className="mt-2">
+            <label className="block text-xs font-medium text-black mb-1">Nota</label>
+            <textarea
+              name="freeNoteText"
+              value={controlInfo.freeNoteText}
+              onChange={(e) => onChange('freeNoteText', e.target.value)}
+              rows={2}
+              className="w-full px-3 py-2 border border-black rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-black"
+            />
+          </div>
+        )}
       </div>
     )}
   </div>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Generador de Cartola de Medicamentos</title>
+    <title>Guía de Medicamentos</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       @media print {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Generador de Cartola de Medicamentos",
-  "description": "Una aplicación para crear cartolas de medicamentos personalizadas para pacientes, con la opción de exportar a PDF para imprimir.",
+  "name": "Guía de Medicamentos",
+  "description": "Una aplicación para crear guías de medicamentos personalizadas para pacientes, con la opción de exportar a PDF para imprimir.",
   "requestFramePermissions": []
 }

--- a/types.ts
+++ b/types.ts
@@ -26,6 +26,7 @@ export interface Medication {
   id: number;
   name: string;
   presentacion: string;
+  description: string;
   dose: Dose;
   frequency: Frequency;
   notes?: string;
@@ -44,10 +45,12 @@ export interface Patient {
 export enum InjectableType {
     NPH = 'Lenta (NPH)',
     CRYSTALLINE = 'Rápida (Cristalina)',
-    LANTUS = 'Lantus',
-    TRESIBA = 'Tresiba',
+    LANTUS = 'Insulina Lantus (Glargina 100 UI/ml)',
+    TOUJEO = 'Insulina Toujeo (Glargina 300 UI/ml)',
+    TRESIBA = 'Insulina Tresiba (Degludec 100 UI/ml)',
     SEMAGLUTIDE = 'Semaglutide (Ozempic)',
     LIRAGLUTIDE = 'Liraglutide (Victoza)',
+    OTHER = 'Otros',
 }
 
 export enum InjectableSchedule {
@@ -101,4 +104,6 @@ export interface ControlInfo {
   note: string;
   suspendEnabled: boolean;
   suspendText: string;
+  freeNoteEnabled: boolean;
+  freeNoteText: string;
 }


### PR DESCRIPTION
## Summary
- add optional free-note section under suspension
- expand injectable treatment options and allow "Otros"
- support medication descriptions beyond comprimido/cápsula and rename app to "Guía de Medicamentos"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8c8c3a5ec832cbc5d6fc1dc60a078