### PR TITLE
feat: add free note section and new injectable options

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,7 +31,9 @@ const initialControlInfo: ControlInfo = {
     otrosText: '',
     note: '',
     suspendEnabled: false,
-    suspendText: ''
+    suspendText: '',
+    freeNoteEnabled: false,
+    freeNoteText: ''
 };
 
 const App: React.FC = () => {
@@ -134,7 +136,7 @@ const App: React.FC = () => {
         <div className="min-h-screen font-sans text-slate-800">
             <header className="bg-white shadow-md">
                 <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-wrap gap-2 justify-between items-center">
-                    <h1 className="text-2xl font-bold text-blue-700">Generador de Cartola de Medicamentos</h1>
+                    <h1 className="text-2xl font-bold text-blue-700">Guía de Medicamentos</h1>
                     <div className="flex gap-2">
                         <button
                             onClick={handleExportList}

--- a/components/InjectableForm.tsx
+++ b/components/InjectableForm.tsx
@@ -29,8 +29,9 @@ const hourOptions = Array.from({ length: 24 }, (_, i) => {
 const insulinTypes = [
     InjectableType.NPH,
     InjectableType.CRYSTALLINE,
-    InjectableType.LANTUS,
-    InjectableType.TRESIBA,
+    InjectableType.INSULIN_LANTUS,
+    InjectableType.INSULIN_TOUJEO,
+    InjectableType.INSULIN_TRESIBA,
 ];
 
 const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpdateInjectable, editingInjectable, onCancelEdit }) => {

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import { Medication, Frequency, Dose } from '../types';
+import { Medication, Frequency, Dose, DosageForm } from '../types';
 import PlusIcon from './icons/PlusIcon';
 
 interface MedicationFormProps {
@@ -15,6 +15,7 @@ const initialMedState: Omit<Medication, 'id'> = {
     presentacion: '',
     dose: Dose.ONE,
     frequency: Frequency.EVERY_12H,
+    dosageForm: DosageForm.TABLET_CAPSULE,
     notes: '',
     isNewMedication: false,
     doseIncreased: false,
@@ -86,9 +87,9 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     />
                 </div>
             </div>
-             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
                 <div>
-                    <label htmlFor="dose" className="block text-sm font-medium text-slate-600 mb-1">Dosis (comprimidos)</label>
+                    <label htmlFor="dose" className="block text-sm font-medium text-slate-600 mb-1">Dosis</label>
                     <select
                         id="dose"
                         name="dose"
@@ -112,6 +113,20 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     >
                         {Object.values(Frequency).map(freq => (
                             <option key={freq} value={freq}>{freq}</option>
+                        ))}
+                    </select>
+                </div>
+                <div>
+                    <label htmlFor="dosageForm" className="block text-sm font-medium text-slate-600 mb-1">Descripción</label>
+                    <select
+                        id="dosageForm"
+                        name="dosageForm"
+                        value={medication.dosageForm}
+                        onChange={handleChange}
+                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                    >
+                        {Object.values(DosageForm).map(form => (
+                            <option key={form} value={form}>{form}</option>
                         ))}
                     </select>
                 </div>

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -230,7 +230,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     {item.name}
                                                 </p>
                                                 <p className="text-sm text-slate-600">{item.presentacion}</p>
-                                                <p className="text-xs text-slate-500 italic">{`${item.dose} comp. - ${item.frequency}`}</p>
+                                                <p className="text-xs text-slate-500 italic">{`${item.dose} ${item.dosageForm} - ${item.frequency}`}</p>
                                             </td>
                                             <td className="p-2 text-center align-middle cursor-pointer" contentEditable={false} onClick={() => handleDoseClick(item.id, 'morning')}>
                                                 {editableDoses[item.id]?.morning && <DoseVisualizer dose={editableDoses[item.id].morning} className="text-blue-600" />}
@@ -398,6 +398,13 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                         Suspender los siguientes medicamentos
                     </h3>
                     <div className="p-3 border border-black rounded text-black text-sm whitespace-pre-wrap">{controlInfo.suspendText}</div>
+                </section>
+            )}
+
+            {controlInfo.freeNoteEnabled && controlInfo.freeNoteText && (
+                <section className="mb-8">
+                    <h3 className="text-base font-bold text-black mb-2 text-center">Nota</h3>
+                    <div className="p-3 border border-black rounded text-black text-sm whitespace-pre-wrap">{controlInfo.freeNoteText}</div>
                 </section>
             )}
 

--- a/components/SuspensionSection.tsx
+++ b/components/SuspensionSection.tsx
@@ -42,6 +42,36 @@ const SuspensionSection: React.FC<SuspensionSectionProps> = ({ controlInfo, onCh
         />
       </div>
     )}
+    <div>
+      <label htmlFor="freeNoteEnabled" className="block text-sm font-medium text-slate-600 mb-1">
+        Incluir sección nota libre
+      </label>
+      <select
+        id="freeNoteEnabled"
+        name="freeNoteEnabled"
+        value={controlInfo.freeNoteEnabled ? 'yes' : 'no'}
+        onChange={(e) => onChange('freeNoteEnabled', e.target.value === 'yes')}
+        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+      >
+        <option value="no">No</option>
+        <option value="yes">Sí</option>
+      </select>
+    </div>
+    {controlInfo.freeNoteEnabled && (
+      <div>
+        <label htmlFor="freeNoteText" className="block text-xs font-medium text-black mb-1">
+          Nota
+        </label>
+        <textarea
+          id="freeNoteText"
+          name="freeNoteText"
+          value={controlInfo.freeNoteText}
+          onChange={(e) => onChange('freeNoteText', e.target.value)}
+          rows={2}
+          className="w-full px-3 py-2 border border-black rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-black"
+        />
+      </div>
+    )}
   </div>
 );
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Generador de Cartola de Medicamentos</title>
+    <title>Guía de Medicamentos</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       @media print {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Generador de Cartola de Medicamentos",
+  "name": "Guía de Medicamentos",
   "description": "Una aplicación para crear cartolas de medicamentos personalizadas para pacientes, con la opción de exportar a PDF para imprimir.",
   "requestFramePermissions": []
 }

--- a/types.ts
+++ b/types.ts
@@ -22,12 +22,21 @@ export enum Dose {
     FOUR = '4',
 }
 
+export enum DosageForm {
+    TABLET_CAPSULE = 'comprimido/capsula',
+    SOBRE = 'sobre',
+    BICARBONATE_POWDER = 'bicarbonato en polvo',
+    DROPS = 'gotas',
+    OTHER = 'otro',
+}
+
 export interface Medication {
   id: number;
   name: string;
   presentacion: string;
   dose: Dose;
   frequency: Frequency;
+  dosageForm: DosageForm;
   notes?: string;
   isNewMedication?: boolean;
   doseIncreased?: boolean;
@@ -44,10 +53,12 @@ export interface Patient {
 export enum InjectableType {
     NPH = 'Lenta (NPH)',
     CRYSTALLINE = 'Rápida (Cristalina)',
-    LANTUS = 'Lantus',
-    TRESIBA = 'Tresiba',
+    INSULIN_LANTUS = 'Insulina Lantus (Glargina 100 UI/ml)',
+    INSULIN_TOUJEO = 'Insulina Toujeo (Glargina 300 UI/ml)',
+    INSULIN_TRESIBA = 'Insulina Tresiba (Degludec 100 UI/ml)',
     SEMAGLUTIDE = 'Semaglutide (Ozempic)',
     LIRAGLUTIDE = 'Liraglutide (Victoza)',
+    OTHER = 'Otros',
 }
 
 export enum InjectableSchedule {
@@ -101,4 +112,6 @@ export interface ControlInfo {
   note: string;
   suspendEnabled: boolean;
   suspendText: string;
+  freeNoteEnabled: boolean;
+  freeNoteText: string;
 }


### PR DESCRIPTION
## Summary
- add optional free note section after suspension section
- expand injectable types and include "otros" option
- allow specifying medication form and update app title to "Guía de Medicamentos"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8c8c3a5ec832cbc5d6fc1dc60a078