### PR TITLE
Include patient info on export and default Liraglutide dose

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -104,7 +104,7 @@ const App: React.FC = () => {
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const handleExportList = () => {
-        const data = { medications, injectables, inhalers };
+        const data = { patient, medications, injectables, inhalers };
         const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
@@ -124,6 +124,13 @@ const App: React.FC = () => {
                 setMedications(data.medications || []);
                 setInjectables(data.injectables || []);
                 setInhalers(data.inhalers || []);
+                if (data.patient) {
+                    setPatient({
+                        name: data.patient.name || '',
+                        rut: data.patient.rut || '',
+                        date: data.patient.date || today,
+                    });
+                }
             } catch (err) {
                 console.error('Error al importar lista', err);
             }

--- a/components/InjectableForm.tsx
+++ b/components/InjectableForm.tsx
@@ -48,12 +48,23 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
     }, [editingInjectable]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-        const { name, type } = e.target;
-        const value = type === 'checkbox' ? (e.target as HTMLInputElement).checked : e.target.value;
-        setInjectable(prev => ({
-            ...prev,
-            [name]: value,
-        }));
+        const { name, type, value } = e.target as HTMLInputElement;
+        if (name === 'type') {
+            const newType = value as InjectableType;
+            let defaultDose = '';
+            if (newType === InjectableType.SEMAGLUTIDE) {
+                defaultDose = '0.25 mg/sem';
+            } else if (newType === InjectableType.LIRAGLUTIDE) {
+                defaultDose = '0.6 mg/día';
+            }
+            setInjectable(prev => ({ ...prev, type: newType, dose: defaultDose }));
+        } else {
+            const val = type === 'checkbox' ? (e.target as HTMLInputElement).checked : value;
+            setInjectable(prev => ({
+                ...prev,
+                [name]: val,
+            }));
+        }
     };
 
     const handleSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- Persist patient data alongside medication lists when exporting and importing
- Pre-select 0.6 mg/día for Liraglutide to ensure it saves without manual change

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9e33801a0832cabdb7df9798179c0