### PR TITLE
Fix Liraglutide default dose and include patient info in exports

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -104,7 +104,7 @@ const App: React.FC = () => {
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const handleExportList = () => {
-        const data = { medications, injectables, inhalers };
+        const data = { patient, medications, injectables, inhalers };
         const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
@@ -121,6 +121,7 @@ const App: React.FC = () => {
         reader.onload = ev => {
             try {
                 const data = JSON.parse(ev.target?.result as string);
+                setPatient(data.patient || { name: '', rut: '', date: today });
                 setMedications(data.medications || []);
                 setInjectables(data.injectables || []);
                 setInhalers(data.inhalers || []);

--- a/components/InjectableForm.tsx
+++ b/components/InjectableForm.tsx
@@ -50,10 +50,13 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
         const { name, type } = e.target;
         const value = type === 'checkbox' ? (e.target as HTMLInputElement).checked : e.target.value;
-        setInjectable(prev => ({
-            ...prev,
-            [name]: value,
-        }));
+        setInjectable(prev => {
+            const updated = { ...prev, [name]: value };
+            if (name === 'type') {
+                updated.dose = value === InjectableType.LIRAGLUTIDE ? '0.6 mg/día' : '';
+            }
+            return updated;
+        });
     };
 
     const handleSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- Include patient info when exporting/importing medication lists
- Default Liraglutide to 0.6 mg/día so it appears in the schedule when added

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9e33801a0832cabdb7df9798179c0