### PR TITLE
Add printable glycemia log section

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import MoneyIcon from './components/icons/MoneyIcon';
 import StarIcon from './components/icons/StarIcon';
 import ArrowUpIcon from './components/icons/ArrowUpIcon';
 import ArrowDownIcon from './components/icons/ArrowDownIcon';
+import GlycemiaLog from './components/GlycemiaLog';
 
 const initialControlInfo: ControlInfo = {
     applies: 'no',
@@ -48,6 +49,7 @@ const App: React.FC = () => {
     const [editingInhaler, setEditingInhaler] = useState<Inhaler | null>(null);
     const [activeTab, setActiveTab] = useState<'oral' | 'injectable' | 'inhaled'>('oral');
     const [showQr, setShowQr] = useState(false);
+    const [activeSection, setActiveSection] = useState<'medications' | 'glycemia'>('medications');
 
 
     const previewRef = useRef<HTMLDivElement>(null);
@@ -138,23 +140,47 @@ const App: React.FC = () => {
         <div className="min-h-screen font-sans text-slate-800">
             <header className="bg-white shadow-md">
                 <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-wrap gap-2 justify-between items-center">
-                    <h1 className="text-2xl font-bold text-blue-700">Guía de Medicamentos</h1>
+                    <div className="flex items-center gap-4">
+                        <h1 className="text-2xl font-bold text-blue-700">
+                            {activeSection === 'medications' ? 'Guía de Medicamentos' : 'Registro de Glicemia'}
+                        </h1>
+                        <nav className="flex gap-2">
+                            <button
+                                className={`text-sm font-semibold ${activeSection === 'medications' ? 'border-b-2 border-blue-500' : ''}`}
+                                onClick={() => setActiveSection('medications')}
+                                type="button"
+                            >
+                                Medicamentos
+                            </button>
+                            <button
+                                className={`text-sm font-semibold ${activeSection === 'glycemia' ? 'border-b-2 border-blue-500' : ''}`}
+                                onClick={() => setActiveSection('glycemia')}
+                                type="button"
+                            >
+                                Registro glicemia
+                            </button>
+                        </nav>
+                    </div>
                     <div className="flex gap-2">
-                        <button
-                            onClick={handleExportList}
-                            className="bg-blue-600 hover:bg-blue-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-1"
-                        >
-                            <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M3 3a2 2 0 012-2h6a2 2 0 012 2v3h-2V3H5v14h6v-3h2v3a2 2 0 01-2 2H5a2 2 0 01-2-2V3z"/><path d="M9 7h2v5h3l-4 4-4-4h3V7z"/></svg>
-                            Exportar Lista
-                        </button>
-                        <button
-                            onClick={handleImportClick}
-                            className="bg-yellow-600 hover:bg-yellow-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-1"
-                        >
-                            <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M3 3a2 2 0 012-2h6a2 2 0 012 2v3h-2V3H5v14h6v-3h2v3a2 2 0 01-2 2H5a2 2 0 01-2-2V3z"/><path d="M11 13H9V8H6l4-4 4 4h-3v5z"/></svg>
-                            Importar Lista
-                        </button>
-                        <input ref={fileInputRef} type="file" accept="application/json" className="hidden" onChange={handleImportList} />
+                        {activeSection === 'medications' && (
+                            <>
+                                <button
+                                    onClick={handleExportList}
+                                    className="bg-blue-600 hover:bg-blue-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-1"
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M3 3a2 2 0 012-2h6a2 2 0 012 2v3h-2V3H5v14h6v-3h2v3a2 2 0 01-2 2H5a2 2 0 01-2-2V3z"/><path d="M9 7h2v5h3l-4 4-4-4h3V7z"/></svg>
+                                    Exportar Lista
+                                </button>
+                                <button
+                                    onClick={handleImportClick}
+                                    className="bg-yellow-600 hover:bg-yellow-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-1"
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M3 3a2 2 0 012-2h6a2 2 0 012 2v3h-2V3H5v14h6v-3h2v3a2 2 0 01-2 2H5a2 2 0 01-2-2V3z"/><path d="M11 13H9V8H6l4-4 4 4h-3v5z"/></svg>
+                                    Importar Lista
+                                </button>
+                                <input ref={fileInputRef} type="file" accept="application/json" className="hidden" onChange={handleImportList} />
+                            </>
+                        )}
                         <button
                             onClick={handlePrint}
                             className="bg-green-600 hover:bg-green-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-1"
@@ -168,7 +194,8 @@ const App: React.FC = () => {
                 </div>
             </header>
 
-            <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 grid grid-cols-1 lg:grid-cols-2 gap-8">
+            {activeSection === 'medications' ? (
+                <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 grid grid-cols-1 lg:grid-cols-2 gap-8">
                 {/* Control Panel */}
                 <div className="bg-white p-6 rounded-xl shadow-lg space-y-8">
                     <PatientInfoForm patient={patient} onChange={handlePatientChange} showQr={showQr} onToggleQr={setShowQr} />
@@ -389,7 +416,12 @@ const App: React.FC = () => {
                      />
                    </div>
                 </div>
-            </main>
+                </main>
+            ) : (
+                <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                    <GlycemiaLog />
+                </main>
+            )}
         </div>
     );
 };

--- a/components/GlycemiaLog.tsx
+++ b/components/GlycemiaLog.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+
+const defaultColumns = ['Fecha', 'AD', 'AA', 'AO', 'AC', '22:00-23:00', 'Nota'];
+
+const GlycemiaLog: React.FC = () => {
+  const [columns, setColumns] = useState<string[]>(defaultColumns);
+  const [showNextControl, setShowNextControl] = useState(false);
+  const [patientName, setPatientName] = useState('');
+  const [rut, setRut] = useState('');
+  const [therapy, setTherapy] = useState('');
+  const [nextControl, setNextControl] = useState('');
+
+  const handleColumnChange = (index: number, value: string) => {
+    setColumns(prev => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  return (
+    <div className="bg-white p-8 rounded-lg shadow-xl w-full max-w-4xl mx-auto border border-slate-200">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+        <div>
+          <label htmlFor="patientName" className="block text-sm font-medium text-slate-600 mb-1">Nombre</label>
+          <input
+            id="patientName"
+            type="text"
+            value={patientName}
+            onChange={(e) => setPatientName(e.target.value)}
+            className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="rut" className="block text-sm font-medium text-slate-600 mb-1">Rut</label>
+          <input
+            id="rut"
+            type="text"
+            value={rut}
+            onChange={(e) => setRut(e.target.value)}
+            className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <label htmlFor="therapy" className="block text-sm font-medium text-slate-600 mb-1">Terapia insulínica indicada</label>
+          <input
+            id="therapy"
+            type="text"
+            value={therapy}
+            onChange={(e) => setTherapy(e.target.value)}
+            className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+        <div className="sm:col-span-2 flex items-center gap-2">
+          <input
+            id="nextControlEnabled"
+            type="checkbox"
+            checked={showNextControl}
+            onChange={(e) => setShowNextControl(e.target.checked)}
+          />
+          <label htmlFor="nextControlEnabled" className="text-sm font-medium text-slate-600">Próximo control</label>
+          {showNextControl && (
+            <input
+              type="text"
+              value={nextControl}
+              onChange={(e) => setNextControl(e.target.value)}
+              className="flex-1 px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse border border-slate-400 text-sm">
+          <thead>
+            <tr>
+              {columns.map((col, idx) => (
+                <th key={idx} className="border border-slate-400 p-1">
+                  <input
+                    value={col}
+                    onChange={(e) => handleColumnChange(idx, e.target.value)}
+                    className="w-full text-center font-semibold focus:outline-none"
+                  />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 25 }).map((_, rowIdx) => (
+              <tr key={rowIdx} className="h-8">
+                {columns.map((_, colIdx) => (
+                  <td key={colIdx} className="border border-slate-400" />
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mt-4 text-sm text-slate-600">
+        Abreviaturas: AD = antes de desayuno. AA = antes de almuerzo. AO = antes de once. AC = antes de cena.
+      </p>
+    </div>
+  );
+};
+
+export default GlycemiaLog;
+


### PR DESCRIPTION
## Summary
- add navigation to switch between medication guide and a new glycemia log
- implement glycemia log with patient info, optional next control and editable table for daily readings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab40d668a4832cba79b11fdf389732