### PR TITLE
feat: add printable glycemia record table

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import MoneyIcon from './components/icons/MoneyIcon';
 import StarIcon from './components/icons/StarIcon';
 import ArrowUpIcon from './components/icons/ArrowUpIcon';
 import ArrowDownIcon from './components/icons/ArrowDownIcon';
+import GlycemiaTable from './components/GlycemiaTable';
 
 const initialControlInfo: ControlInfo = {
     applies: 'no',
@@ -48,6 +49,7 @@ const App: React.FC = () => {
     const [editingInhaler, setEditingInhaler] = useState<Inhaler | null>(null);
     const [activeTab, setActiveTab] = useState<'oral' | 'injectable' | 'inhaled'>('oral');
     const [showQr, setShowQr] = useState(false);
+    const [activeMainTab, setActiveMainTab] = useState<'medications' | 'glycemia'>('medications');
 
 
     const previewRef = useRef<HTMLDivElement>(null);
@@ -166,230 +168,254 @@ const App: React.FC = () => {
                         </button>
                     </div>
                 </div>
+                <div className="border-t">
+                    <div className="container mx-auto px-4 sm:px-6 lg:px-8 flex">
+                        <button
+                            type="button"
+                            onClick={() => setActiveMainTab('medications')}
+                            className={`flex-1 py-2 text-sm font-semibold ${activeMainTab === 'medications' ? 'border-b-2 border-blue-500' : ''}`}
+                        >
+                            Medicamentos
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setActiveMainTab('glycemia')}
+                            className={`flex-1 py-2 text-sm font-semibold ${activeMainTab === 'glycemia' ? 'border-b-2 border-blue-500' : ''}`}
+                        >
+                            Registro de glicemia
+                        </button>
+                    </div>
+                </div>
             </header>
 
-            <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 grid grid-cols-1 lg:grid-cols-2 gap-8">
-                {/* Control Panel */}
-                <div className="bg-white p-6 rounded-xl shadow-lg space-y-8">
-                    <PatientInfoForm patient={patient} onChange={handlePatientChange} showQr={showQr} onToggleQr={setShowQr} />
-                    <div>
-                        <div className="flex border-b">
-                            <button
-                                className={`flex-1 py-2 text-sm font-semibold ${activeTab === 'oral' ? 'border-b-2 border-blue-500' : ''}`}
-                                onClick={() => setActiveTab('oral')}
-                                type="button"
-                            >
-                                Fármacos orales
-                            </button>
-                            <button
-                                className={`flex-1 py-2 text-sm font-semibold ${activeTab === 'injectable' ? 'border-b-2 border-blue-500' : ''}`}
-                                onClick={() => setActiveTab('injectable')}
-                                type="button"
-                            >
-                                Fármacos inyectables
-                            </button>
-                            <button
-                                className={`flex-1 py-2 text-sm font-semibold ${activeTab === 'inhaled' ? 'border-b-2 border-blue-500' : ''}`}
-                                onClick={() => setActiveTab('inhaled')}
-                                type="button"
-                            >
-                                Fármacos inhalados
-                            </button>
+            {activeMainTab === 'medications' ? (
+                <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 grid grid-cols-1 lg:grid-cols-2 gap-8">
+                    {/* Control Panel */}
+                    <div className="bg-white p-6 rounded-xl shadow-lg space-y-8">
+                        <PatientInfoForm patient={patient} onChange={handlePatientChange} showQr={showQr} onToggleQr={setShowQr} />
+                        <div>
+                            <div className="flex border-b">
+                                <button
+                                    className={`flex-1 py-2 text-sm font-semibold ${activeTab === 'oral' ? 'border-b-2 border-blue-500' : ''}`}
+                                    onClick={() => setActiveTab('oral')}
+                                    type="button"
+                                >
+                                    Fármacos orales
+                                </button>
+                                <button
+                                    className={`flex-1 py-2 text-sm font-semibold ${activeTab === 'injectable' ? 'border-b-2 border-blue-500' : ''}`}
+                                    onClick={() => setActiveTab('injectable')}
+                                    type="button"
+                                >
+                                    Fármacos inyectables
+                                </button>
+                                <button
+                                    className={`flex-1 py-2 text-sm font-semibold ${activeTab === 'inhaled' ? 'border-b-2 border-blue-500' : ''}`}
+                                    onClick={() => setActiveTab('inhaled')}
+                                    type="button"
+                                >
+                                    Fármacos inhalados
+                                </button>
+                            </div>
+                            <div className="pt-4 space-y-4">
+                                {activeTab === 'oral' && (
+                                    <>
+                                        <MedicationForm onAddMedication={addMedication} onUpdateMedication={updateMedication} editingMedication={editingMedication} onCancelEdit={() => setEditingMedication(null)} />
+                                        {medications.length > 0 && (
+                                            <div className="space-y-4">
+                                                <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Medicamentos Añadidos</h3>
+                                                <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
+                                                    {medications.map((med) => (
+                                                        <li key={med.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
+                                                            <div>
+                                                                <p className="font-bold text-blue-600 flex items-center gap-1">
+                                                                    {med.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
+                                                                    {med.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
+                                                                    {med.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
+                                                                    {med.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
+                                                                    {med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span>
+                                                                </p>
+                                                                {(() => {
+                                                                    const description = med.dosageForm === DosageForm.OTHER
+                                                                        ? med.otherDosageForm
+                                                                        : med.dosageForm === DosageForm.NONE
+                                                                            ? ''
+                                                                            : med.dosageForm;
+                                                                    return (
+                                                                        <p className="text-sm text-slate-500">
+                                                                            {`${med.dose}${description ? ` ${description}` : ''} - ${med.frequency}`}
+                                                                        </p>
+                                                                    );
+                                                                })()}
+                                                                {med.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {med.notes}</p>}
+                                                            </div>
+                                                            <div className="flex gap-2">
+                                                                <button
+                                                                    onClick={() => setEditingMedication(med)}
+                                                                    className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
+                                                                    aria-label="Editar medicamento"
+                                                                >
+                                                                    <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
+                                                                </button>
+                                                                <button
+                                                                    onClick={() => removeMedication(med.id)}
+                                                                    className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
+                                                                    aria-label="Eliminar medicamento"
+                                                                >
+                                                                    <TrashIcon className="w-5 h-5" />
+                                                                </button>
+                                                            </div>
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            </div>
+                                        )}
+                                    </>
+                                )}
+                                {activeTab === 'injectable' && (
+                                    <>
+                                        <InjectableForm onAddInjectable={addInjectable} onUpdateInjectable={updateInjectable} editingInjectable={editingInjectable} onCancelEdit={() => setEditingInjectable(null)} />
+                                        {injectables.length > 0 && (
+                                            <div className="space-y-4">
+                                                <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Tratamientos Inyectables Añadidos</h3>
+                                                <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
+                                                    {injectables.map((ins) => (
+                                                        <li key={ins.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
+                                                            <div>
+                                                                <p className="font-bold text-teal-600 flex items-center gap-1">
+                                                                    {ins.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
+                                                                    {ins.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
+                                                                    {ins.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
+                                                                    {ins.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
+                                                                    {ins.type}
+                                                                </p>
+                                                                <p className="text-sm text-slate-500">{`${ins.dose} - ${ins.schedule} a las ${ins.time}`}</p>
+                                                                {ins.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {ins.notes}</p>}
+                                                            </div>
+                                                            <div className="flex gap-2">
+                                                                <button
+                                                                    onClick={() => setEditingInjectable(ins)}
+                                                                    className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
+                                                                    aria-label="Editar inyectable"
+                                                                >
+                                                                    <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
+                                                                </button>
+                                                                <button
+                                                                    onClick={() => removeInjectable(ins.id)}
+                                                                    className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
+                                                                    aria-label="Eliminar inyectable"
+                                                                >
+                                                                    <TrashIcon className="w-5 h-5" />
+                                                                </button>
+                                                            </div>
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            </div>
+                                        )}
+                                    </>
+                                )}
+                                {activeTab === 'inhaled' && (
+                                    <>
+                                        <InhalerForm onAddInhaler={addInhaler} onUpdateInhaler={updateInhaler} editingInhaler={editingInhaler} onCancelEdit={() => setEditingInhaler(null)} />
+                                        {inhalers.length > 0 && (
+                                            <div className="space-y-4">
+                                                <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Inhaladores Añadidos</h3>
+                                                <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
+                                                    {inhalers.map((inh) => (
+                                                        <li key={inh.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
+                                                            <div>
+                                                                <p className="font-bold text-purple-600 flex items-center gap-1">
+                                                                    {inh.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
+                                                                    {inh.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
+                                                                    {inh.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
+                                                                    {inh.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
+                                                                    {inh.name} <span className="text-slate-600 font-normal">{inh.presentacion}</span>
+                                                                </p>
+                                                                <p className="text-sm text-slate-500">{`${inh.dose} puff(s) - cada ${inh.frequencyHours} h`}</p>
+                                                                {inh.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {inh.notes}</p>}
+                                                            </div>
+                                                            <div className="flex gap-2">
+                                                                <button
+                                                                    onClick={() => setEditingInhaler(inh)}
+                                                                    className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
+                                                                    aria-label="Editar inhalador"
+                                                                >
+                                                                    <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
+                                                                </button>
+                                                                <button
+                                                                    onClick={() => removeInhaler(inh.id)}
+                                                                    className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
+                                                                    aria-label="Eliminar inhalador"
+                                                                >
+                                                                    <TrashIcon className="w-5 h-5" />
+                                                                </button>
+                                                            </div>
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            </div>
+                                        )}
+                                    </>
+                                )}
+                            </div>
                         </div>
-                        <div className="pt-4 space-y-4">
-                            {activeTab === 'oral' && (
-                                <>
-                                    <MedicationForm onAddMedication={addMedication} onUpdateMedication={updateMedication} editingMedication={editingMedication} onCancelEdit={() => setEditingMedication(null)} />
-                                    {medications.length > 0 && (
-                                        <div className="space-y-4">
-                                            <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Medicamentos Añadidos</h3>
-                                            <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
-                                                {medications.map((med) => (
-                                                    <li key={med.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
-                                                        <div>
-                                                            <p className="font-bold text-blue-600 flex items-center gap-1">
-                                                                {med.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
-                                                                {med.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
-                                                                {med.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
-                                                                {med.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
-                                                                {med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span>
-                                                            </p>
-                                                            {(() => {
-                                                                const description = med.dosageForm === DosageForm.OTHER
-                                                                    ? med.otherDosageForm
-                                                                    : med.dosageForm === DosageForm.NONE
-                                                                        ? ''
-                                                                        : med.dosageForm;
-                                                                return (
-                                                                    <p className="text-sm text-slate-500">
-                                                                        {`${med.dose}${description ? ` ${description}` : ''} - ${med.frequency}`}
-                                                                    </p>
-                                                                );
-                                                            })()}
-                                                            {med.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {med.notes}</p>}
-                                                        </div>
-                                                        <div className="flex gap-2">
-                                                            <button
-                                                                onClick={() => setEditingMedication(med)}
-                                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
-                                                                aria-label="Editar medicamento"
-                                                            >
-                                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
-                                                            </button>
-                                                            <button
-                                                                onClick={() => removeMedication(med.id)}
-                                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
-                                                                aria-label="Eliminar medicamento"
-                                                            >
-                                                                <TrashIcon className="w-5 h-5" />
-                                                            </button>
-                                                        </div>
-                                                    </li>
-                                                ))}
-                                            </ul>
-                                        </div>
-                                    )}
-                                </>
-                            )}
-                            {activeTab === 'injectable' && (
-                                <>
-                                    <InjectableForm onAddInjectable={addInjectable} onUpdateInjectable={updateInjectable} editingInjectable={editingInjectable} onCancelEdit={() => setEditingInjectable(null)} />
-                                    {injectables.length > 0 && (
-                                        <div className="space-y-4">
-                                            <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Tratamientos Inyectables Añadidos</h3>
-                                            <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
-                                                {injectables.map((ins) => (
-                                                    <li key={ins.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
-                                                        <div>
-                                                            <p className="font-bold text-teal-600 flex items-center gap-1">
-                                                                {ins.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
-                                                                {ins.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
-                                                                {ins.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
-                                                                {ins.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
-                                                                {ins.type}
-                                                            </p>
-                                                            <p className="text-sm text-slate-500">{`${ins.dose} - ${ins.schedule} a las ${ins.time}`}</p>
-                                                            {ins.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {ins.notes}</p>}
-                                                        </div>
-                                                        <div className="flex gap-2">
-                                                            <button
-                                                                onClick={() => setEditingInjectable(ins)}
-                                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
-                                                                aria-label="Editar inyectable"
-                                                            >
-                                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
-                                                            </button>
-                                                            <button
-                                                                onClick={() => removeInjectable(ins.id)}
-                                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
-                                                                aria-label="Eliminar inyectable"
-                                                            >
-                                                                <TrashIcon className="w-5 h-5" />
-                                                            </button>
-                                                        </div>
-                                                    </li>
-                                                ))}
-                                            </ul>
-                                        </div>
-                                    )}
-                                </>
-                            )}
-                            {activeTab === 'inhaled' && (
-                                <>
-                                    <InhalerForm onAddInhaler={addInhaler} onUpdateInhaler={updateInhaler} editingInhaler={editingInhaler} onCancelEdit={() => setEditingInhaler(null)} />
-                                    {inhalers.length > 0 && (
-                                        <div className="space-y-4">
-                                            <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Inhaladores Añadidos</h3>
-                                            <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
-                                                {inhalers.map((inh) => (
-                                                    <li key={inh.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
-                                                        <div>
-                                                            <p className="font-bold text-purple-600 flex items-center gap-1">
-                                                                {inh.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
-                                                                {inh.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
-                                                                {inh.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
-                                                                {inh.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
-                                                                {inh.name} <span className="text-slate-600 font-normal">{inh.presentacion}</span>
-                                                            </p>
-                                                            <p className="text-sm text-slate-500">{`${inh.dose} puff(s) - cada ${inh.frequencyHours} h`}</p>
-                                                            {inh.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {inh.notes}</p>}
-                                                        </div>
-                                                        <div className="flex gap-2">
-                                                            <button
-                                                                onClick={() => setEditingInhaler(inh)}
-                                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
-                                                                aria-label="Editar inhalador"
-                                                            >
-                                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
-                                                            </button>
-                                                            <button
-                                                                onClick={() => removeInhaler(inh.id)}
-                                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
-                                                                aria-label="Eliminar inhalador"
-                                                            >
-                                                                <TrashIcon className="w-5 h-5" />
-                                                            </button>
-                                                        </div>
-                                                    </li>
-                                                ))}
-                                            </ul>
-                                        </div>
-                                    )}
-                                </>
-                            )}
+
+                        <SuspensionSection controlInfo={controlInfo} onChange={handleControlChange} />
+                        <div className="space-y-2 pt-4 border-t border-slate-200">
+                            <label htmlFor="professional" className="block text-sm font-medium text-slate-600 mb-1">Profesional</label>
+                            <input
+                                type="text"
+                                id="professional"
+                                name="professional"
+                                value={controlInfo.professional}
+                                onChange={(e) => handleControlChange('professional', e.target.value)}
+                                className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                            />
                         </div>
+                        <ControlInfoForm controlInfo={controlInfo} onChange={handleControlChange} />
                     </div>
 
-                    <SuspensionSection controlInfo={controlInfo} onChange={handleControlChange} />
-                    <div className="space-y-2 pt-4 border-t border-slate-200">
-                        <label htmlFor="professional" className="block text-sm font-medium text-slate-600 mb-1">Profesional</label>
-                        <input
-                            type="text"
-                            id="professional"
-                            name="professional"
-                            value={controlInfo.professional}
-                            onChange={(e) => handleControlChange('professional', e.target.value)}
-                            className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                        />
+                    {/* Preview Panel */}
+                    <div className="bg-slate-200 p-4 sm:p-6 rounded-xl shadow-inner flex items-start justify-center overflow-x-auto">
+                       <div ref={previewRef} className="w-full">
+                         <SchedulePreview
+                           patient={patient}
+                           medications={medications}
+                           injectables={injectables}
+                           inhalers={inhalers}
+                           controlInfo={controlInfo}
+                           showQr={showQr}
+                           onEditMedication={(id) => {
+                             const med = medications.find(m => m.id === id);
+                             if (med) {
+                               setActiveTab('oral');
+                               setEditingMedication(med);
+                             }
+                           }}
+                           onEditInjectable={(id) => {
+                             const inj = injectables.find(i => i.id === id);
+                             if (inj) {
+                               setActiveTab('injectable');
+                               setEditingInjectable(inj);
+                             }
+                           }}
+                           onEditInhaler={(id) => {
+                             const inh = inhalers.find(i => i.id === id);
+                             if (inh) {
+                               setActiveTab('inhaled');
+                               setEditingInhaler(inh);
+                             }
+                           }}
+                         />
+                       </div>
                     </div>
-                    <ControlInfoForm controlInfo={controlInfo} onChange={handleControlChange} />
-                </div>
-
-                {/* Preview Panel */}
-                <div className="bg-slate-200 p-4 sm:p-6 rounded-xl shadow-inner flex items-start justify-center overflow-x-auto">
-                   <div ref={previewRef} className="w-full">
-                     <SchedulePreview
-                       patient={patient}
-                       medications={medications}
-                       injectables={injectables}
-                       inhalers={inhalers}
-                       controlInfo={controlInfo}
-                       showQr={showQr}
-                       onEditMedication={(id) => {
-                         const med = medications.find(m => m.id === id);
-                         if (med) {
-                           setActiveTab('oral');
-                           setEditingMedication(med);
-                         }
-                       }}
-                       onEditInjectable={(id) => {
-                         const inj = injectables.find(i => i.id === id);
-                         if (inj) {
-                           setActiveTab('injectable');
-                           setEditingInjectable(inj);
-                         }
-                       }}
-                       onEditInhaler={(id) => {
-                         const inh = inhalers.find(i => i.id === id);
-                         if (inh) {
-                           setActiveTab('inhaled');
-                           setEditingInhaler(inh);
-                         }
-                       }}
-                     />
-                   </div>
-                </div>
-            </main>
+                </main>
+            ) : (
+                <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                    <GlycemiaTable />
+                </main>
+            )}
         </div>
     );
 };

--- a/components/GlycemiaTable.tsx
+++ b/components/GlycemiaTable.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+
+const rowCount = 26; // number of rows to nearly fill letter-size page
+
+const GlycemiaTable: React.FC = () => {
+    const [info, setInfo] = useState({
+        name: '',
+        rut: '',
+        therapy: '',
+        nextControlEnabled: false,
+        nextControl: '',
+    });
+
+    const [headers, setHeaders] = useState({
+        fecha: 'Fecha',
+        ad: 'AD',
+        aa: 'AA',
+        ao: 'AO',
+        ac: 'AC',
+        late: '22:00-23:00',
+        note: 'Nota',
+    });
+
+    const handleInfoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value, type, checked } = e.target;
+        setInfo(prev => ({
+            ...prev,
+            [name]: type === 'checkbox' ? checked : value,
+        }));
+    };
+
+    const handleHeaderChange = (key: keyof typeof headers, value: string) => {
+        setHeaders(prev => ({ ...prev, [key]: value }));
+    };
+
+    const columnKeys = Object.keys(headers) as (keyof typeof headers)[];
+
+    return (
+        <div id="schedule-preview" className="bg-white p-8 rounded-lg shadow-xl w-full max-w-3xl mx-auto border border-slate-200">
+            <header className="mb-4 border-b-2 pb-4 border-slate-200">
+                <h2 className="mt-0 mb-2 text-2xl font-extrabold text-blue-700 leading-tight">Registro de Glicemia</h2>
+                <div className="text-sm space-y-2">
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                        <label className="font-semibold">Nombre:</label>
+                        <input
+                            name="name"
+                            value={info.name}
+                            onChange={handleInfoChange}
+                            className="flex-1 border-b border-slate-300 focus:outline-none"
+                        />
+                    </div>
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                        <label className="font-semibold">RUT:</label>
+                        <input
+                            name="rut"
+                            value={info.rut}
+                            onChange={handleInfoChange}
+                            className="flex-1 border-b border-slate-300 focus:outline-none"
+                        />
+                    </div>
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                        <label className="font-semibold">Terapia insulínica indicada:</label>
+                        <input
+                            name="therapy"
+                            value={info.therapy}
+                            onChange={handleInfoChange}
+                            className="flex-1 border-b border-slate-300 focus:outline-none"
+                        />
+                    </div>
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                        <label className="font-semibold flex items-center gap-2">
+                            <input
+                                type="checkbox"
+                                name="nextControlEnabled"
+                                checked={info.nextControlEnabled}
+                                onChange={handleInfoChange}
+                            />
+                            Próximo control
+                        </label>
+                        {info.nextControlEnabled && (
+                            <input
+                                name="nextControl"
+                                value={info.nextControl}
+                                onChange={handleInfoChange}
+                                className="flex-1 border-b border-slate-300 focus:outline-none"
+                            />
+                        )}
+                    </div>
+                </div>
+            </header>
+
+            <table className="w-full border border-slate-400 border-collapse text-xs">
+                <thead>
+                    <tr>
+                        {columnKeys.map(key => (
+                            <th key={key} className="border border-slate-400 p-1">
+                                <input
+                                    value={headers[key]}
+                                    onChange={e => handleHeaderChange(key, e.target.value)}
+                                    className="w-full text-center font-semibold bg-transparent focus:outline-none"
+                                />
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {Array.from({ length: rowCount }).map((_, idx) => (
+                        <tr key={idx} className="h-6">
+                            {columnKeys.map(col => (
+                                <td key={col} className="border border-slate-400"></td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+
+            <p className="mt-4 text-xs">
+                Abreviaturas: AD = antes de desayuno. AA = antes de almuerzo. AO = antes de once. AC = antes de cena.
+            </p>
+        </div>
+    );
+};
+
+export default GlycemiaTable;
+


### PR DESCRIPTION
## Summary
- add new "Registro de glicemia" tab with printable grid for tracking insulin therapy
- support patient info, optional next control note and editable column headers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab40d668a4832cba79b11fdf389732