### PR TITLE
Agregar registro de glicemia imprimible

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import MoneyIcon from './components/icons/MoneyIcon';
 import StarIcon from './components/icons/StarIcon';
 import ArrowUpIcon from './components/icons/ArrowUpIcon';
 import ArrowDownIcon from './components/icons/ArrowDownIcon';
+import GlycemiaTable from './components/GlycemiaTable';
 
 const initialControlInfo: ControlInfo = {
     applies: 'no',
@@ -48,6 +49,7 @@ const App: React.FC = () => {
     const [editingInhaler, setEditingInhaler] = useState<Inhaler | null>(null);
     const [activeTab, setActiveTab] = useState<'oral' | 'injectable' | 'inhaled'>('oral');
     const [showQr, setShowQr] = useState(false);
+    const [activeSection, setActiveSection] = useState<'main' | 'glycemia'>('main');
 
 
     const previewRef = useRef<HTMLDivElement>(null);
@@ -134,6 +136,16 @@ const App: React.FC = () => {
 
     const handleImportClick = () => fileInputRef.current?.click();
 
+    if (activeSection === 'glycemia') {
+        return (
+            <GlycemiaTable
+                patient={patient}
+                onPatientChange={handlePatientChange}
+                onBack={() => setActiveSection('main')}
+            />
+        );
+    }
+
     return (
         <div className="min-h-screen font-sans text-slate-800">
             <header className="bg-white shadow-md">
@@ -163,6 +175,15 @@ const App: React.FC = () => {
                                 <path fillRule="evenodd" d="M6 2a2 2 0 00-2 2v2h12V4a2 2 0 00-2-2H6zm10 6H4v8a2 2 0 002 2h8a2 2 0 002-2V8zM6 10h8v2H6v-2z" clipRule="evenodd" />
                             </svg>
                             Imprimir / Guardar PDF
+                        </button>
+                        <button
+                            onClick={() => setActiveSection('glycemia')}
+                            className="bg-purple-600 hover:bg-purple-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-1"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20">
+                                <path d="M3 3h14v14H3V3zm1 1v4h12V4H4zm0 5v8h3V9H4zm4 0v8h8V9H8z" />
+                            </svg>
+                            Tabla Glicemia
                         </button>
                     </div>
                 </div>

--- a/components/GlycemiaTable.tsx
+++ b/components/GlycemiaTable.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { Patient } from '../types';
+
+interface GlycemiaTableProps {
+  patient: Patient;
+  onPatientChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBack: () => void;
+}
+
+const defaultColumns = ['Fecha', 'AD', 'AA', 'AO', 'AC', '22:00-23:00', 'Nota'];
+
+const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ patient, onPatientChange, onBack }) => {
+  const [therapy, setTherapy] = useState('');
+  const [nextEnabled, setNextEnabled] = useState(false);
+  const [nextText, setNextText] = useState('');
+  const [columns, setColumns] = useState<string[]>(defaultColumns);
+
+  const handleColumnChange = (idx: number, value: string) => {
+    setColumns(prev => prev.map((c, i) => (i === idx ? value : c)));
+  };
+
+  const handlePrint = () => {
+    window.print();
+  };
+
+  const rows = Array.from({ length: 26 });
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-4">
+      <div className="flex justify-between">
+        <button
+          onClick={onBack}
+          className="px-4 py-2 bg-slate-300 rounded hover:bg-slate-400"
+        >
+          Volver
+        </button>
+        <button
+          onClick={handlePrint}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Imprimir
+        </button>
+      </div>
+      <div id="glycemia-table" className="space-y-4">
+        <h1 className="text-2xl font-bold text-center">Registro de Glicemia</h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="name" className="block text-sm font-medium text-slate-600 mb-1">Nombre</label>
+            <input
+              type="text"
+              id="name"
+              name="name"
+              value={patient.name}
+              onChange={onPatientChange}
+              className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm"
+            />
+          </div>
+          <div>
+            <label htmlFor="rut" className="block text-sm font-medium text-slate-600 mb-1">Rut</label>
+            <input
+              type="text"
+              id="rut"
+              name="rut"
+              value={patient.rut}
+              onChange={onPatientChange}
+              className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm"
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="therapy" className="block text-sm font-medium text-slate-600 mb-1">Terapia insulínica indicada</label>
+          <input
+            type="text"
+            id="therapy"
+            value={therapy}
+            onChange={(e) => setTherapy(e.target.value)}
+            className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm"
+          />
+        </div>
+        <div>
+          <label className="inline-flex items-center gap-2 text-sm font-medium text-slate-600">
+            <input
+              type="checkbox"
+              checked={nextEnabled}
+              onChange={(e) => setNextEnabled(e.target.checked)}
+              className="h-4 w-4 text-blue-600"
+            />
+            Próximo control
+          </label>
+          {nextEnabled && (
+            <textarea
+              value={nextText}
+              onChange={(e) => setNextText(e.target.value)}
+              className="mt-2 w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm"
+            />
+          )}
+        </div>
+        <table className="w-full border-collapse border border-slate-400 text-sm">
+          <thead>
+            <tr>
+              {columns.map((col, i) => (
+                <th key={i} className="border border-slate-400 p-1">
+                  <input
+                    className="w-full text-center font-semibold"
+                    value={col}
+                    onChange={(e) => handleColumnChange(i, e.target.value)}
+                  />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((_, r) => (
+              <tr key={r}>
+                {columns.map((_, c) => (
+                  <td key={c} className="border border-slate-400 h-6"></td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="text-xs text-slate-600">
+          Abreviaturas: AD = antes de desayuno. AA = antes de almuerzo. AO = antes de once. AC = antes de cena.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default GlycemiaTable;

--- a/index.html
+++ b/index.html
@@ -9,8 +9,9 @@
     <style>
       @media print {
         body * { visibility: hidden; }
-        #schedule-preview, #schedule-preview * { visibility: visible; }
-        #schedule-preview { position: absolute; left: 0; top: 0; width: 100%; }
+        #schedule-preview, #schedule-preview *,
+        #glycemia-table, #glycemia-table * { visibility: visible; }
+        #schedule-preview, #glycemia-table { position: absolute; left: 0; top: 0; width: 100%; }
       }
     </style>
 <script type="importmap">


### PR DESCRIPTION
## Summary
- Añade una nueva sección para registrar glicemia con edición de columnas y datos de terapia.
- Permite alternar desde la guía de medicamentos hacia la tabla de glicemia.
- Ajusta estilos de impresión para incluir la nueva tabla.

## Testing
- `npm test` (falla: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab40d668a4832cba79b11fdf389732