### PR TITLE
Add configuration toolbar to glycemia table

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -73,7 +73,15 @@ const App: React.FC = () => {
     }, []);
 
     const addInjectable = useCallback((inj: Omit<Injectable, 'id'>) => {
-        setInjectables(prev => [...prev, { ...inj, id: Date.now() }]);
+        setInjectables(prev => {
+            const idx = prev.findIndex(i => i.type === inj.type && i.schedule === inj.schedule);
+            if (idx !== -1) {
+                const updated = [...prev];
+                updated[idx] = { ...prev[idx], ...inj };
+                return updated;
+            }
+            return [...prev, { ...inj, id: Date.now() }];
+        });
     }, []);
 
     const updateInjectable = useCallback((id: number, inj: Omit<Injectable, 'id'>) => {

--- a/components/GlycemiaTable.tsx
+++ b/components/GlycemiaTable.tsx
@@ -49,7 +49,8 @@ const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
 
   return (
     <>
-      <div className="fixed top-0 left-0 right-0 bg-black p-1 flex items-center gap-2 text-xs print:hidden z-50">
+      {/* Development toolbar - hidden when printing */}
+      <div className="fixed top-0 left-0 right-0 bg-black px-2 py-1 flex items-center gap-2 text-xs text-white print:hidden z-50">
         <button
           onClick={handleAddColumn}
           className="bg-green-600 hover:bg-green-500 text-white px-2 py-1 rounded flex items-center gap-1"
@@ -87,7 +88,7 @@ const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
         >
           Volver
         </button>
-        <label className="flex items-center gap-1 ml-2 text-white">
+        <label className="flex items-center gap-1 ml-2">
           Filas:
           <input
             type="number"

--- a/components/GlycemiaTable.tsx
+++ b/components/GlycemiaTable.tsx
@@ -134,8 +134,8 @@ const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
         </div>
 
         {showGoals && (
-          <div className="flex-1">
-            <h3 className="text-base font-semibold mb-1">Metas Metabólicas</h3>
+          <div className="flex-1 relative">
+            <h3 className="absolute -top-5 left-0 text-base font-semibold">Metas Metabólicas</h3>
             <div className="border border-gray-300 p-2 rounded-md bg-gray-50 flex flex-col">
               <div className="flex flex-wrap gap-2 mb-2">
                 <div className="flex flex-col flex-1 min-w-[120px]">

--- a/components/GlycemiaTable.tsx
+++ b/components/GlycemiaTable.tsx
@@ -1,4 +1,7 @@
 import React, { useState } from 'react';
+import PlusIcon from './icons/PlusIcon';
+
+// TODO: sección con planillas predeterminadas para registro glicémico
 
 interface Column {
   id: string;
@@ -24,7 +27,8 @@ interface GlycemiaTableProps {
 const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
   const [columns, setColumns] = useState<Column[]>(initialColumns);
   const [showGoals, setShowGoals] = useState(false);
-  const rows = Array.from({ length: 30 });
+  const [rowCount, setRowCount] = useState(30);
+  const rows = Array.from({ length: rowCount });
 
   const handleAddColumn = () => {
     const newCol: Column = {
@@ -44,8 +48,49 @@ const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
   };
 
   return (
-    <div id="glycemia-table" className="p-4 font-sans text-black">
-      <h2 className="text-2xl font-bold mb-4">Registro de Automonitoreo de Glicemia</h2>
+    <>
+      <div className="fixed top-0 left-0 right-0 bg-black text-white p-1 flex items-center gap-2 text-xs print:hidden z-50">
+        <button
+          onClick={handleAddColumn}
+          className="p-1 hover:text-gray-300"
+          type="button"
+          title="Agregar columna"
+        >
+          <PlusIcon className="h-4 w-4" />
+        </button>
+        <button
+          onClick={() => window.print()}
+          className="p-1 hover:text-gray-300"
+          type="button"
+          title="Imprimir"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M6 2a2 2 0 00-2 2v2h12V4a2 2 0 00-2-2H6zm10 6H4v8a2 2 0 002 2h8a2 2 0 002-2V8zM6 10h8v2H6v-2z" clipRule="evenodd" />
+          </svg>
+        </button>
+        <button
+          onClick={onBack}
+          className="p-1 hover:text-gray-300"
+          type="button"
+          title="Volver"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M9.707 14.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 011.414 1.414L6.414 8H17a1 1 0 110 2H6.414l3.293 3.293a1 1 0 010 1.414z" clipRule="evenodd" />
+          </svg>
+        </button>
+        <label className="flex items-center gap-1 ml-2">
+          Filas:
+          <input
+            type="number"
+            min={1}
+            value={rowCount}
+            onChange={e => setRowCount(Number(e.target.value))}
+            className="w-12 text-black rounded p-0.5"
+          />
+        </label>
+      </div>
+      <div id="glycemia-table" className="p-4 pt-8 font-sans text-black">
+        <h2 className="text-2xl font-bold mb-4">Registro de Automonitoreo de Glicemia</h2>
 
       <div className="flex items-stretch mb-4">
         <div
@@ -136,27 +181,6 @@ const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
           />
           Metas
         </label>
-        <button
-          onClick={handleAddColumn}
-          className="bg-blue-600 hover:bg-blue-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md"
-          type="button"
-        >
-          Agregar columna
-        </button>
-        <button
-          onClick={() => window.print()}
-          className="bg-green-600 hover:bg-green-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md"
-          type="button"
-        >
-          Imprimir
-        </button>
-        <button
-          onClick={onBack}
-          className="bg-gray-600 hover:bg-gray-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md"
-          type="button"
-        >
-          Volver
-        </button>
       </div>
       
       <div className="overflow-auto">
@@ -210,6 +234,7 @@ const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
         </table>
       </div>
     </div>
+    </>
   );
 };
 

--- a/components/GlycemiaTable.tsx
+++ b/components/GlycemiaTable.tsx
@@ -49,36 +49,45 @@ const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
 
   return (
     <>
-      <div className="fixed top-0 left-0 right-0 bg-black text-white p-1 flex items-center gap-2 text-xs print:hidden z-50">
+      <div className="fixed top-0 left-0 right-0 bg-black p-1 flex items-center gap-2 text-xs print:hidden z-50">
         <button
           onClick={handleAddColumn}
-          className="p-1 hover:text-gray-300"
+          className="bg-green-600 hover:bg-green-500 text-white px-2 py-1 rounded flex items-center gap-1"
           type="button"
           title="Agregar columna"
         >
           <PlusIcon className="h-4 w-4" />
+          <span>Agregar columna</span>
         </button>
         <button
           onClick={() => window.print()}
-          className="p-1 hover:text-gray-300"
+          className="bg-blue-600 hover:bg-blue-500 text-white px-2 py-1 rounded flex items-center gap-1"
           type="button"
           title="Imprimir"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M6 2a2 2 0 00-2 2v2h12V4a2 2 0 00-2-2H6zm10 6H4v8a2 2 0 002 2h8a2 2 0 002-2V8zM6 10h8v2H6v-2z" clipRule="evenodd" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M6 2a2 2 0 00-2 2v2h12V4a2 2 0 00-2-2H6zm10 6H4v8a2 2 0 002 2h8a2 2 0 002-2V8zM6 10h8v2H6v-2z"
+              clipRule="evenodd"
+            />
           </svg>
+          <span>Imprimir</span>
         </button>
         <button
           onClick={onBack}
-          className="p-1 hover:text-gray-300"
+          className="bg-gray-600 hover:bg-gray-500 text-white px-2 py-1 rounded"
           type="button"
           title="Volver"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M9.707 14.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 011.414 1.414L6.414 8H17a1 1 0 110 2H6.414l3.293 3.293a1 1 0 010 1.414z" clipRule="evenodd" />
-          </svg>
+          Volver
         </button>
-        <label className="flex items-center gap-1 ml-2">
+        <label className="flex items-center gap-1 ml-2 text-white">
           Filas:
           <input
             type="number"
@@ -92,7 +101,7 @@ const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
       <div id="glycemia-table" className="p-4 pt-8 font-sans text-black">
         <h2 className="text-2xl font-bold mb-4">Registro de Automonitoreo de Glicemia</h2>
 
-      <div className="flex items-stretch mb-4">
+      <div className="flex items-start mb-4">
         <div
           className={`border border-gray-300 p-4 rounded-md bg-gray-50 flex-1 flex flex-col ${
             showGoals ? 'mr-4' : ''
@@ -124,49 +133,51 @@ const GlycemiaTable: React.FC<GlycemiaTableProps> = ({ onBack, patient }) => {
         </div>
 
         {showGoals && (
-          <div className="border border-gray-300 p-4 rounded-md bg-gray-50 flex-1 flex flex-col">
-            <h3 className="text-center text-base font-semibold mb-3">Metas Metabólicas</h3>
-            <div className="flex flex-wrap gap-3 mb-3">
-              <div className="flex flex-col flex-1 min-w-[120px]">
-                <label className="font-bold text-xs mb-1">Hb Glicosilada</label>
+          <div className="flex-1">
+            <h3 className="text-base font-semibold mb-1">Metas Metabólicas</h3>
+            <div className="border border-gray-300 p-2 rounded-md bg-gray-50 flex flex-col">
+              <div className="flex flex-wrap gap-2 mb-2">
+                <div className="flex flex-col flex-1 min-w-[120px]">
+                  <label className="font-bold text-xs mb-1">Hb Glicosilada</label>
+                  <input
+                    type="text"
+                    placeholder="Ej: <7%"
+                    className="p-1 border border-gray-300 rounded text-xs"
+                  />
+                </div>
+                <div className="flex flex-col flex-1 min-w-[120px]">
+                  <label className="font-bold text-xs mb-1">Glicemia Ayuno</label>
+                  <input
+                    type="text"
+                    placeholder="Ej: 80-130 mg/dL"
+                    className="p-1 border border-gray-300 rounded text-xs"
+                  />
+                </div>
+                <div className="flex flex-col flex-1 min-w-[120px]">
+                  <label className="font-bold text-xs mb-1">Glicemias Pre-Comidas</label>
+                  <input
+                    type="text"
+                    placeholder="Ej: 90-130 mg/dL"
+                    className="p-1 border border-gray-300 rounded text-xs"
+                  />
+                </div>
+                <div className="flex flex-col flex-1 min-w-[120px]">
+                  <label className="font-bold text-xs mb-1">Presión arterial</label>
+                  <input
+                    type="text"
+                    placeholder="Ej: 120/80 mmHg"
+                    className="p-1 border border-gray-300 rounded text-xs"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col">
+                <label className="font-bold text-xs mb-1">Nota</label>
                 <input
                   type="text"
-                  placeholder="Ej: <7%"
+                  placeholder="Observaciones"
                   className="p-1 border border-gray-300 rounded text-xs"
                 />
               </div>
-              <div className="flex flex-col flex-1 min-w-[120px]">
-                <label className="font-bold text-xs mb-1">Glicemia Ayuno</label>
-                <input
-                  type="text"
-                  placeholder="Ej: 80-130 mg/dL"
-                  className="p-1 border border-gray-300 rounded text-xs"
-                />
-              </div>
-              <div className="flex flex-col flex-1 min-w-[120px]">
-                <label className="font-bold text-xs mb-1">Glicemias Pre-Comidas</label>
-                <input
-                  type="text"
-                  placeholder="Ej: 90-130 mg/dL"
-                  className="p-1 border border-gray-300 rounded text-xs"
-                />
-              </div>
-              <div className="flex flex-col flex-1 min-w-[120px]">
-                <label className="font-bold text-xs mb-1">Presión arterial</label>
-                <input
-                  type="text"
-                  placeholder="Ej: 120/80 mmHg"
-                  className="p-1 border border-gray-300 rounded text-xs"
-                />
-              </div>
-            </div>
-            <div className="flex flex-col">
-              <label className="font-bold text-xs mb-1">Nota</label>
-              <input
-                type="text"
-                placeholder="Observaciones"
-                className="p-1 border border-gray-300 rounded text-xs"
-              />
             </div>
           </div>
         )}

--- a/components/InjectableDoseVisualizer.tsx
+++ b/components/InjectableDoseVisualizer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import SyringeIcon from './icons/SyringeIcon';
 
 interface InjectableDoseVisualizerProps {
     dose: string;
@@ -9,8 +8,7 @@ interface InjectableDoseVisualizerProps {
 
 const InjectableDoseVisualizer: React.FC<InjectableDoseVisualizerProps> = ({ dose, time, className }) => {
     return (
-        <div className={`inline-flex flex-col items-center justify-center gap-1.5 ${className}`}>
-            <SyringeIcon className="w-8 h-8" />
+        <div className={`inline-flex flex-col items-center justify-center gap-1 ${className}`}>
             <span className="font-bold text-base uppercase tracking-wide">{dose}</span>
             <span className="font-semibold text-xs">{time}</span>
         </div>

--- a/components/InjectableForm.tsx
+++ b/components/InjectableForm.tsx
@@ -29,6 +29,7 @@ const hourOptions = Array.from({ length: 24 }, (_, i) => {
 const insulinTypes = [
     InjectableType.NPH,
     InjectableType.CRYSTALLINE,
+    InjectableType.ULTRA_RAPID,
     InjectableType.INSULIN_LANTUS,
     InjectableType.INSULIN_TOUJEO,
     InjectableType.INSULIN_TRESIBA,
@@ -37,6 +38,10 @@ const insulinTypes = [
 const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpdateInjectable, editingInjectable, onCancelEdit }) => {
     const [injectable, setInjectable] = useState<Omit<Injectable, 'id'>>(initialInjectableState);
     const [customDose, setCustomDose] = useState('');
+    const isRapid = injectable.type === InjectableType.CRYSTALLINE || injectable.type === InjectableType.ULTRA_RAPID;
+    const scheduleOptions = isRapid
+        ? [InjectableSchedule.AD, InjectableSchedule.AA, InjectableSchedule.AO, InjectableSchedule.AC]
+        : [InjectableSchedule.MAÑANA, InjectableSchedule.NOCHE];
 
     useEffect(() => {
         if (editingInjectable) {
@@ -54,6 +59,10 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
             const updated = { ...prev, [name]: value };
             if (name === 'type') {
                 updated.dose = value === InjectableType.LIRAGLUTIDE ? '0.6 mg/día' : '';
+                updated.schedule =
+                    value === InjectableType.CRYSTALLINE || value === InjectableType.ULTRA_RAPID
+                        ? InjectableSchedule.AD
+                        : InjectableSchedule.MAÑANA;
             }
             return updated;
         });
@@ -62,10 +71,15 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         let finalDose = injectable.dose;
+        let finalTime = injectable.time;
 
         if (insulinTypes.includes(injectable.type)) {
             if (!injectable.dose) return;
             finalDose = `${injectable.dose} U`;
+            if (isRapid) {
+                const match = injectable.schedule.match(/\((.*)\)/);
+                finalTime = match ? match[1] : injectable.schedule;
+            }
         } else if (injectable.type === InjectableType.SEMAGLUTIDE) {
             if (injectable.dose === 'other') {
                 if (!customDose) return;
@@ -80,10 +94,10 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
         }
 
         if (editingInjectable) {
-            onUpdateInjectable && onUpdateInjectable(editingInjectable.id, { ...injectable, dose: finalDose });
+            onUpdateInjectable && onUpdateInjectable(editingInjectable.id, { ...injectable, dose: finalDose, time: finalTime });
             onCancelEdit && onCancelEdit();
         } else {
-            onAddInjectable({ ...injectable, dose: finalDose });
+            onAddInjectable({ ...injectable, dose: finalDose, time: finalTime });
         }
         setInjectable(initialInjectableState);
         setCustomDose('');
@@ -182,11 +196,12 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                         onChange={handleChange}
                         className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                     >
-                        {Object.values(InjectableSchedule).map(s => (
+                        {scheduleOptions.map(s => (
                             <option key={s} value={s}>{s}</option>
                         ))}
                     </select>
                 </div>
+                {!isRapid && (
                 <div>
                     <label htmlFor="time" className="block text-sm font-medium text-slate-600 mb-1">Indicar Hora</label>
                     <select
@@ -202,6 +217,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                         ))}
                     </select>
                 </div>
+                )}
             </div>
 
             <div className="grid grid-cols-2 gap-2">

--- a/components/InjectableForm.tsx
+++ b/components/InjectableForm.tsx
@@ -26,7 +26,7 @@ const hourOptions = Array.from({ length: 24 }, (_, i) => {
     return `${hour}:00`;
 });
 
-const insulinTypes = [
+const insulinTypes: string[] = [
     InjectableType.NPH,
     InjectableType.CRYSTALLINE,
     InjectableType.ULTRA_RAPID,
@@ -38,6 +38,7 @@ const insulinTypes = [
 const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpdateInjectable, editingInjectable, onCancelEdit }) => {
     const [injectable, setInjectable] = useState<Omit<Injectable, 'id'>>(initialInjectableState);
     const [customDose, setCustomDose] = useState('');
+    const [customType, setCustomType] = useState('');
     const isRapid = injectable.type === InjectableType.CRYSTALLINE || injectable.type === InjectableType.ULTRA_RAPID;
     const scheduleOptions = isRapid
         ? [InjectableSchedule.AD, InjectableSchedule.AA, InjectableSchedule.AO, InjectableSchedule.AC]
@@ -46,34 +47,51 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
     useEffect(() => {
         if (editingInjectable) {
             const { id, ...rest } = editingInjectable;
-            setInjectable(rest);
+            if (Object.values(InjectableType).includes(rest.type as InjectableType)) {
+                setInjectable(rest as Omit<Injectable, 'id'>);
+                setCustomType('');
+            } else {
+                setInjectable({ ...rest, type: InjectableType.OTHER });
+                setCustomType(rest.type);
+            }
         } else {
             setInjectable(initialInjectableState);
+            setCustomType('');
         }
     }, [editingInjectable]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
         const { name, type } = e.target;
         const value = type === 'checkbox' ? (e.target as HTMLInputElement).checked : e.target.value;
+        setInjectable(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value as InjectableType;
         setInjectable(prev => {
-            const updated = { ...prev, [name]: value };
-            if (name === 'type') {
-                updated.dose = value === InjectableType.LIRAGLUTIDE ? '0.6 mg/día' : '';
-                updated.schedule =
-                    value === InjectableType.CRYSTALLINE || value === InjectableType.ULTRA_RAPID
-                        ? InjectableSchedule.AD
-                        : InjectableSchedule.MAÑANA;
-            }
+            const updated = { ...prev, type: value };
+            updated.dose = value === InjectableType.LIRAGLUTIDE ? '0.6 mg/día' : '';
+            updated.schedule =
+                value === InjectableType.CRYSTALLINE || value === InjectableType.ULTRA_RAPID
+                    ? InjectableSchedule.AD
+                    : InjectableSchedule.MAÑANA;
             return updated;
         });
+        if (value !== InjectableType.OTHER) {
+            setCustomType('');
+        }
     };
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         let finalDose = injectable.dose;
         let finalTime = injectable.time;
+        const trimmedCustomType = customType.trim();
+        let finalType = injectable.type === InjectableType.OTHER ? (trimmedCustomType || InjectableType.OTHER) : injectable.type;
 
-        if (insulinTypes.includes(injectable.type)) {
+        if (injectable.type === InjectableType.OTHER && !trimmedCustomType) return;
+
+        if (insulinTypes.includes(finalType)) {
             if (!injectable.dose) return;
             finalDose = `${injectable.dose} U`;
             if (isRapid) {
@@ -93,13 +111,21 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
             finalDose = injectable.dose.toLowerCase();
         }
 
+        const finalInjectable = { ...injectable, type: finalType, dose: finalDose, time: finalTime };
         if (editingInjectable) {
-            onUpdateInjectable && onUpdateInjectable(editingInjectable.id, { ...injectable, dose: finalDose, time: finalTime });
+            onUpdateInjectable && onUpdateInjectable(editingInjectable.id, finalInjectable);
             onCancelEdit && onCancelEdit();
         } else {
-            onAddInjectable({ ...injectable, dose: finalDose, time: finalTime });
+            onAddInjectable(finalInjectable);
         }
-        setInjectable(initialInjectableState);
+
+        if (injectable.type === InjectableType.OTHER) {
+            setInjectable({ ...initialInjectableState, type: InjectableType.OTHER });
+            setCustomType(trimmedCustomType);
+        } else {
+            setInjectable({ ...initialInjectableState, type: injectable.type });
+            setCustomType('');
+        }
         setCustomDose('');
     };
 
@@ -117,13 +143,22 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                     id="injectableType"
                     name="type"
                     value={injectable.type}
-                    onChange={handleChange}
+                    onChange={handleTypeChange}
                     className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                 >
                     {Object.values(InjectableType).map(type => (
                         <option key={type} value={type}>{type}</option>
                     ))}
                 </select>
+                {injectable.type === InjectableType.OTHER && (
+                    <input
+                        type="text"
+                        className="mt-2 w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        placeholder="Especificar"
+                        value={customType}
+                        onChange={e => setCustomType(e.target.value)}
+                    />
+                )}
             </div>
 
             {insulinTypes.includes(injectable.type) && (

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Patient, Medication, Frequency, Dose, DosageForm, Injectable, InjectableSchedule, InjectableType, ControlInfo, Inhaler } from '../types';
+import { Patient, Medication, Frequency, Dose, DosageForm, Injectable, InjectableSchedule, ControlInfo, Inhaler } from '../types';
 import DoseVisualizer from './DoseVisualizer';
 import MoonIcon from './icons/MoonIcon';
 import SunIcon from './icons/SunIcon';
@@ -111,7 +111,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
             acc.set(inj.type, data);
         }
         return acc;
-    }, new Map<InjectableType, { mañana: Injectable[]; noche: Injectable[]; ad: Injectable[]; aa: Injectable[]; ao: Injectable[]; ac: Injectable[]; isNewMedication: boolean; doseIncreased: boolean; doseDecreased: boolean; requiresPurchase: boolean }>());
+    }, new Map<string, { mañana: Injectable[]; noche: Injectable[]; ad: Injectable[]; aa: Injectable[]; ao: Injectable[]; ac: Injectable[]; isNewMedication: boolean; doseIncreased: boolean; doseDecreased: boolean; requiresPurchase: boolean }>());
 
     const medicationItems = medications.map(med => ({ ...med, itemType: 'medication' as const }));
 

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -10,6 +10,7 @@ import ArrowUpIcon from './icons/ArrowUpIcon';
 import ArrowDownIcon from './icons/ArrowDownIcon';
 import EditIcon from './icons/EditIcon';
 import RedCrossIcon from './icons/RedCrossIcon';
+import SyringeIcon from './icons/SyringeIcon';
 
 interface SchedulePreviewProps {
     patient: Patient;
@@ -442,17 +443,17 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     )}
                                                     {item.type}
                                                 </p>
-                                                <p className="text-sm text-teal-600">Inyectable</p>
+                                                <SyringeIcon className="w-5 h-5 text-teal-600 mx-auto" />
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                <div className="flex flex-col items-center gap-2">
+                                                <div className="flex flex-row flex-wrap justify-center items-center gap-2">
                                                     {[...item.schedules.mañana, ...item.schedules.ad].map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                <div className="flex flex-col items-center gap-2">
+                                                <div className="flex flex-row flex-wrap justify-center items-center gap-2">
                                                     {item.schedules.aa.map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}
@@ -462,7 +463,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                 </div>
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                <div className="flex flex-col items-center gap-2">
+                                                <div className="flex flex-row flex-wrap justify-center items-center gap-2">
                                                     {[...item.schedules.ac, ...item.schedules.noche].map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -129,6 +129,11 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
         requiresPurchase: data.requiresPurchase,
     }));
 
+    const getDisplayTime = (ins: Injectable): string => {
+        const match = ins.schedule.match(/\((.*)\)/);
+        return match ? match[1] : ins.time;
+    };
+
     const allItems = [...medicationItems, ...inhalerItems, ...injectableItems];
 
     const formattedControlDate = controlInfo.date ? new Date(`${controlInfo.date}T${controlInfo.time || '00:00'}`).toLocaleString('es-CL', { dateStyle: 'short', timeStyle: 'short' }) : '';
@@ -448,24 +453,24 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
                                                 <div className="flex flex-row flex-wrap justify-center items-center gap-2">
                                                     {[...item.schedules.mañana, ...item.schedules.ad].map(ins => (
-                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
+                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={getDisplayTime(ins)} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
                                                 <div className="flex flex-row flex-wrap justify-center items-center gap-2">
                                                     {item.schedules.aa.map(ins => (
-                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
+                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={getDisplayTime(ins)} className="text-blue-600"/>
                                                     ))}
                                                     {item.schedules.ao.map(ins => (
-                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
+                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={getDisplayTime(ins)} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
                                                 <div className="flex flex-row flex-wrap justify-center items-center gap-2">
                                                     {[...item.schedules.ac, ...item.schedules.noche].map(ins => (
-                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
+                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={getDisplayTime(ins)} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -79,28 +79,38 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
 
     const groupedInjectables = injectables.reduce((acc, inj) => {
         const existing = acc.get(inj.type);
+        const addToSchedule = (obj: { mañana: Injectable[]; noche: Injectable[]; ad: Injectable[]; aa: Injectable[]; ao: Injectable[]; ac: Injectable[] }) => {
+            if (inj.schedule === InjectableSchedule.MAÑANA) obj.mañana.push(inj);
+            else if (inj.schedule === InjectableSchedule.NOCHE) obj.noche.push(inj);
+            else if (inj.schedule === InjectableSchedule.AD) obj.ad.push(inj);
+            else if (inj.schedule === InjectableSchedule.AA) obj.aa.push(inj);
+            else if (inj.schedule === InjectableSchedule.AO) obj.ao.push(inj);
+            else if (inj.schedule === InjectableSchedule.AC) obj.ac.push(inj);
+        };
         if (existing) {
-            if (inj.schedule === InjectableSchedule.MAÑANA) {
-                existing.mañana.push(inj);
-            } else {
-                existing.noche.push(inj);
-            }
+            addToSchedule(existing);
             existing.isNewMedication ||= inj.isNewMedication;
             existing.doseIncreased ||= inj.doseIncreased;
             existing.doseDecreased ||= inj.doseDecreased;
             existing.requiresPurchase ||= inj.requiresPurchase;
         } else {
-            acc.set(inj.type, {
-                mañana: inj.schedule === InjectableSchedule.MAÑANA ? [inj] : [],
-                noche: inj.schedule === InjectableSchedule.NOCHE ? [inj] : [],
+            const data = {
+                mañana: [],
+                noche: [],
+                ad: [],
+                aa: [],
+                ao: [],
+                ac: [],
                 isNewMedication: inj.isNewMedication || false,
                 doseIncreased: inj.doseIncreased || false,
                 doseDecreased: inj.doseDecreased || false,
                 requiresPurchase: inj.requiresPurchase || false,
-            });
+            };
+            addToSchedule(data);
+            acc.set(inj.type, data);
         }
         return acc;
-    }, new Map<InjectableType, { mañana: Injectable[], noche: Injectable[], isNewMedication: boolean, doseIncreased: boolean, doseDecreased: boolean, requiresPurchase: boolean }>());
+    }, new Map<InjectableType, { mañana: Injectable[]; noche: Injectable[]; ad: Injectable[]; aa: Injectable[]; ao: Injectable[]; ac: Injectable[]; isNewMedication: boolean; doseIncreased: boolean; doseDecreased: boolean; requiresPurchase: boolean }>());
 
     const medicationItems = medications.map(med => ({ ...med, itemType: 'medication' as const }));
 
@@ -108,10 +118,10 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
 
     const injectableItems = Array.from(groupedInjectables.entries()).map(([type, data]) => ({
         id: type,
-        editId: data.mañana[0]?.id ?? data.noche[0]?.id,
+        editId: data.mañana[0]?.id ?? data.noche[0]?.id ?? data.ad[0]?.id ?? data.aa[0]?.id ?? data.ao[0]?.id ?? data.ac[0]?.id,
         itemType: 'injectable' as const,
         type,
-        schedules: { mañana: data.mañana, noche: data.noche },
+        schedules: { mañana: data.mañana, noche: data.noche, ad: data.ad, aa: data.aa, ao: data.ao, ac: data.ac },
         isNewMedication: data.isNewMedication,
         doseIncreased: data.doseIncreased,
         doseDecreased: data.doseDecreased,
@@ -134,7 +144,10 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
     };
 
     const oralStrings = medications.map(m => `${m.name} ${m.presentacion} ${frequencyShortMap[m.frequency] ?? m.frequency}`);
-    const injectableStrings = injectables.map(i => `${i.type} ${i.dose} ${i.schedule.toLowerCase()}`);
+    const injectableStrings = injectables.map(i => {
+        const sched = i.schedule.match(/\((.*)\)/);
+        return `${i.type} ${i.dose} ${(sched ? sched[1] : i.schedule).toLowerCase()}`;
+    });
     const inhalerStrings = inhalers.map(h => `${h.name} inh ${h.presentacion} c/${h.frequencyHours}h`);
     const medsParam = [...oralStrings, ...injectableStrings, ...inhalerStrings].join('||');
 
@@ -384,7 +397,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                         </tr>
                                     );
                                 } else { // item.itemType === 'injectable'
-                                    const allNotes = [...item.schedules.mañana, ...item.schedules.noche]
+                                    const allNotes = [...item.schedules.mañana, ...item.schedules.noche, ...item.schedules.ad, ...item.schedules.aa, ...item.schedules.ao, ...item.schedules.ac]
                                         .map(ins => ins.notes)
                                         .filter(Boolean)
                                         .join('\n');
@@ -433,17 +446,24 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
                                                 <div className="flex flex-col items-center gap-2">
-                                                    {item.schedules.mañana.map(ins => (
+                                                    {[...item.schedules.mañana, ...item.schedules.ad].map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                {/* typically not used in the afternoon */}
+                                                <div className="flex flex-col items-center gap-2">
+                                                    {item.schedules.aa.map(ins => (
+                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
+                                                    ))}
+                                                    {item.schedules.ao.map(ins => (
+                                                        <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
+                                                    ))}
+                                                </div>
                                             </td>
                                             <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                 <div className="flex flex-col items-center gap-2">
-                                                    {item.schedules.noche.map(ins => (
+                                                <div className="flex flex-col items-center gap-2">
+                                                    {[...item.schedules.ac, ...item.schedules.noche].map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={ins.time} className="text-blue-600"/>
                                                     ))}
                                                 </div>

--- a/types.ts
+++ b/types.ts
@@ -54,7 +54,7 @@ export interface Patient {
 export enum InjectableType {
     NPH = 'Insulina NPH',
     CRYSTALLINE = 'Insulina Rápida',
-    ULTRA_RAPID = 'Insulina ultrarápida (UR)',
+    ULTRA_RAPID = 'Insulina ultrarápida',
     INSULIN_LANTUS = 'Insulina Lantus (Glargina 100 UI/ml)',
     INSULIN_TOUJEO = 'Insulina Toujeo (Glargina 300 UI/ml)',
     INSULIN_TRESIBA = 'Insulina Tresiba (Degludec 100 UI/ml)',

--- a/types.ts
+++ b/types.ts
@@ -74,7 +74,7 @@ export enum InjectableSchedule {
 
 export interface Injectable {
     id: number;
-    type: InjectableType;
+    type: string;
     dose: string;
     schedule: InjectableSchedule;
     time: string; // "HH:mm" format

--- a/types.ts
+++ b/types.ts
@@ -52,8 +52,9 @@ export interface Patient {
 }
 
 export enum InjectableType {
-    NPH = 'Lenta (NPH)',
-    CRYSTALLINE = 'Rápida (Cristalina)',
+    NPH = 'Insulina NPH',
+    CRYSTALLINE = 'Insulina Rápida',
+    ULTRA_RAPID = 'Insulina ultrarápida (UR)',
     INSULIN_LANTUS = 'Insulina Lantus (Glargina 100 UI/ml)',
     INSULIN_TOUJEO = 'Insulina Toujeo (Glargina 300 UI/ml)',
     INSULIN_TRESIBA = 'Insulina Tresiba (Degludec 100 UI/ml)',
@@ -65,6 +66,10 @@ export enum InjectableType {
 export enum InjectableSchedule {
     MAÑANA = 'Mañana',
     NOCHE = 'Noche',
+    AD = 'Antes desayuno (AD)',
+    AA = 'Antes almuerzo (AA)',
+    AO = 'Antes once (AO)',
+    AC = 'Antes cena (AC)',
 }
 
 export interface Injectable {


### PR DESCRIPTION
## Summary
- add top black toolbar for glycemia table development with icons for adding columns, printing, and returning
- allow setting row count from toolbar and hide it when printing
- note placeholder for future preset glycemia templates

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c048cbf99c832ca24df96bb27ba270