### PR TITLE
Add medication categories and drag reordering

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useRef, useCallback } from 'react';
-import { Patient, Medication, Injectable, ControlInfo, ExamOptions, Inhaler, DosageForm } from './types';
+import { Patient, Medication, Injectable, ControlInfo, ExamOptions, Inhaler, DosageForm, MedicationCategory } from './types';
 import PatientInfoForm from './components/PatientInfoForm';
 import MedicationForm from './components/MedicationForm';
 import InjectableForm from './components/InjectableForm';
@@ -37,6 +37,41 @@ const initialControlInfo: ControlInfo = {
     freeNoteText: ''
 };
 
+const medicationCategoryOrder = [
+    MedicationCategory.CARDIOVASCULAR,
+    MedicationCategory.DIABETES,
+    MedicationCategory.INSULIN_GLP1,
+    MedicationCategory.OTHER,
+];
+
+const medicationCategoryLabels: Record<MedicationCategory, string> = {
+    [MedicationCategory.CARDIOVASCULAR]: 'Cardiovascular / Hipertensión',
+    [MedicationCategory.DIABETES]: 'Diabetes',
+    [MedicationCategory.INSULIN_GLP1]: 'Insulinas y agonistas GLP-1',
+    [MedicationCategory.OTHER]: 'Otros',
+};
+
+type MedicationInput = Omit<Medication, 'id' | 'order'>;
+
+const normalizeMedications = (meds: Medication[]): Medication[] => {
+    const normalized = meds.map((med, index) => ({
+        ...med,
+        category: med.category ?? MedicationCategory.OTHER,
+        order: typeof med.order === 'number' ? med.order : index,
+    }));
+
+    const orderedByCategory = medicationCategoryOrder.flatMap(category => {
+        const medsInCategory = normalized
+            .filter(m => m.category === category)
+            .sort((a, b) => a.order - b.order);
+        return medsInCategory.map((med, idx) => ({ ...med, order: idx }));
+    });
+
+    const leftovers = normalized.filter(m => !medicationCategoryOrder.includes(m.category));
+
+    return [...orderedByCategory, ...leftovers];
+};
+
 const App: React.FC = () => {
     const today = new Date().toISOString().split('T')[0];
     const [patient, setPatient] = useState<Patient>({ name: '', rut: '', date: today });
@@ -51,6 +86,7 @@ const App: React.FC = () => {
     const [showQr, setShowQr] = useState(false);
     const [view, setView] = useState<'guide' | 'glycemia'>('guide');
     const [showAppsMenu, setShowAppsMenu] = useState(false);
+    const [draggedMedicationId, setDraggedMedicationId] = useState<number | null>(null);
 
     const previewRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -60,16 +96,58 @@ const App: React.FC = () => {
         setPatient(prev => ({ ...prev, [name]: value }));
     }, []);
 
-    const addMedication = useCallback((med: Omit<Medication, 'id'>) => {
-        setMedications(prev => [...prev, { ...med, id: Date.now() }]);
+    const addMedication = useCallback((med: MedicationInput) => {
+        setMedications(prev => {
+            const medsInCategory = prev.filter(m => m.category === med.category);
+            const nextOrder = medsInCategory.length
+                ? Math.max(...medsInCategory.map(m => m.order)) + 1
+                : 0;
+            return [...prev, { ...med, id: Date.now(), order: nextOrder }];
+        });
     }, []);
 
-    const updateMedication = useCallback((id: number, med: Omit<Medication, 'id'>) => {
+    const updateMedication = useCallback((id: number, med: MedicationInput) => {
         setMedications(prev => prev.map(m => m.id === id ? { ...m, ...med } : m));
     }, []);
 
     const removeMedication = useCallback((id: number) => {
-        setMedications(prev => prev.filter(med => med.id !== id));
+        setMedications(prev => {
+            const medToRemove = prev.find(med => med.id === id);
+            if (!medToRemove) return prev;
+            const filtered = prev.filter(med => med.id !== id);
+            const medsInCategory = filtered
+                .filter(med => med.category === medToRemove.category)
+                .sort((a, b) => a.order - b.order)
+                .map((med, index) => ({ ...med, order: index }));
+            const otherMeds = filtered.filter(med => med.category !== medToRemove.category);
+            return [...otherMeds, ...medsInCategory];
+        });
+    }, []);
+
+    const handleMedicationReorder = useCallback((sourceId: number, targetId: number) => {
+        if (sourceId === targetId) return;
+        setMedications(prev => {
+            const sourceMed = prev.find(med => med.id === sourceId);
+            const targetMed = prev.find(med => med.id === targetId);
+            if (!sourceMed || !targetMed || sourceMed.category !== targetMed.category) {
+                return prev;
+            }
+            const medsInCategory = prev
+                .filter(med => med.category === sourceMed.category)
+                .sort((a, b) => a.order - b.order);
+            const sourceIndex = medsInCategory.findIndex(med => med.id === sourceId);
+            const targetIndex = medsInCategory.findIndex(med => med.id === targetId);
+            if (sourceIndex === -1 || targetIndex === -1) return prev;
+            const updatedCategory = [...medsInCategory];
+            const [removed] = updatedCategory.splice(sourceIndex, 1);
+            updatedCategory.splice(targetIndex, 0, removed);
+            const orderMap = new Map(updatedCategory.map((med, index) => [med.id, index]));
+            return prev.map(med =>
+                med.category === sourceMed.category && orderMap.has(med.id)
+                    ? { ...med, order: orderMap.get(med.id)! }
+                    : med
+            );
+        });
     }, []);
 
     const addInjectable = useCallback((inj: Omit<Injectable, 'id'>) => {
@@ -131,7 +209,7 @@ const App: React.FC = () => {
             try {
                 const data = JSON.parse(ev.target?.result as string);
                 setPatient(data.patient || { name: '', rut: '', date: today });
-                setMedications(data.medications || []);
+                setMedications(normalizeMedications(data.medications || []));
                 setInjectables(data.injectables || []);
                 setInhalers(data.inhalers || []);
             } catch (err) {
@@ -142,6 +220,16 @@ const App: React.FC = () => {
     };
 
     const handleImportClick = () => fileInputRef.current?.click();
+
+    const medicationsByCategory = medicationCategoryOrder.map(category => ({
+        category,
+        label: medicationCategoryLabels[category],
+        meds: medications
+            .filter(med => med.category === category)
+            .sort((a, b) => a.order - b.order),
+    }));
+
+    const hasMedications = medicationsByCategory.some(group => group.meds.length > 0);
 
     if (view === 'glycemia') {
         return <GlycemiaTable onBack={() => setView('guide')} patient={patient} />;
@@ -235,53 +323,85 @@ const App: React.FC = () => {
                             {activeTab === 'oral' && (
                                 <>
                                     <MedicationForm onAddMedication={addMedication} onUpdateMedication={updateMedication} editingMedication={editingMedication} onCancelEdit={() => setEditingMedication(null)} />
-                                    {medications.length > 0 && (
+                                    {hasMedications && (
                                         <div className="space-y-4">
-                                            <h3 className="text-xl font-semibold text-slate-700 border-b pb-2">Medicamentos Añadidos</h3>
-                                            <ul className="space-y-3 max-h-60 overflow-y-auto pr-2">
-                                                {medications.map((med) => (
-                                                    <li key={med.id} className="flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm">
-                                                        <div>
-                                                            <p className="font-bold text-blue-600 flex items-center gap-1">
-                                                                {med.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
-                                                                {med.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
-                                                                {med.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
-                                                                {med.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
-                                                                {med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span>
-                                                            </p>
-                                                            {(() => {
-                                                                const description = med.dosageForm === DosageForm.OTHER
-                                                                    ? med.otherDosageForm
-                                                                    : med.dosageForm === DosageForm.NONE
-                                                                        ? ''
-                                                                        : med.dosageForm;
-                                                                return (
-                                                                    <p className="text-sm text-slate-500">
-                                                                        {`${med.dose}${description ? ` ${description}` : ''} - ${med.frequency}`}
-                                                                    </p>
-                                                                );
-                                                            })()}
-                                                            {med.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {med.notes}</p>}
+                                            <div className="flex items-center justify-between border-b pb-2">
+                                                <h3 className="text-xl font-semibold text-slate-700">Medicamentos Añadidos</h3>
+                                                <p className="text-xs text-slate-500">Arrastra y suelta para reordenar dentro de cada categoría.</p>
+                                            </div>
+                                            <div className="space-y-4 max-h-72 overflow-y-auto pr-2">
+                                                {medicationsByCategory.map(({ category, label, meds }) => (
+                                                    meds.length > 0 && (
+                                                        <div key={category} className="space-y-2">
+                                                            <h4 className="text-sm font-semibold text-slate-500 uppercase tracking-wide">{label}</h4>
+                                                            <ul className="space-y-3">
+                                                                {meds.map((med) => (
+                                                                    <li
+                                                                        key={med.id}
+                                                                        className={`flex justify-between items-center bg-slate-50 p-3 rounded-lg shadow-sm border ${draggedMedicationId === med.id ? 'border-blue-400' : 'border-transparent'}`}
+                                                                        draggable
+                                                                        onDragStart={(e) => {
+                                                                            setDraggedMedicationId(med.id);
+                                                                            e.dataTransfer.effectAllowed = 'move';
+                                                                        }}
+                                                                        onDragOver={(e) => {
+                                                                            e.preventDefault();
+                                                                            e.dataTransfer.dropEffect = 'move';
+                                                                        }}
+                                                                        onDrop={(e) => {
+                                                                            e.preventDefault();
+                                                                            if (draggedMedicationId != null) {
+                                                                                handleMedicationReorder(draggedMedicationId, med.id);
+                                                                            }
+                                                                            setDraggedMedicationId(null);
+                                                                        }}
+                                                                        onDragEnd={() => setDraggedMedicationId(null)}
+                                                                    >
+                                                                        <div>
+                                                                            <p className="font-bold text-blue-600 flex items-center gap-1">
+                                                                                {med.isNewMedication && <StarIcon className="inline w-4 h-4 text-yellow-500" />}
+                                                                                {med.doseIncreased && <ArrowUpIcon className="inline w-4 h-4" />}
+                                                                                {med.doseDecreased && <ArrowDownIcon className="inline w-4 h-4" />}
+                                                                                {med.requiresPurchase && <MoneyIcon className="inline w-4 h-4 text-green-600" />}
+                                                                                {med.name} <span className="text-slate-600 font-normal">{med.presentacion}</span>
+                                                                            </p>
+                                                                            {(() => {
+                                                                                const description = med.dosageForm === DosageForm.OTHER
+                                                                                    ? med.otherDosageForm
+                                                                                    : med.dosageForm === DosageForm.NONE
+                                                                                        ? ''
+                                                                                        : med.dosageForm;
+                                                                                return (
+                                                                                    <p className="text-sm text-slate-500">
+                                                                                        {`${med.dose}${description ? ` ${description}` : ''} - ${med.frequency}`}
+                                                                                    </p>
+                                                                                );
+                                                                            })()}
+                                                                            {med.notes && <p className="text-xs text-slate-500 italic mt-1">Nota: {med.notes}</p>}
+                                                                        </div>
+                                                                        <div className="flex gap-2">
+                                                                            <button
+                                                                                onClick={() => setEditingMedication(med)}
+                                                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
+                                                                                aria-label="Editar medicamento"
+                                                                            >
+                                                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
+                                                                            </button>
+                                                                            <button
+                                                                                onClick={() => removeMedication(med.id)}
+                                                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
+                                                                                aria-label="Eliminar medicamento"
+                                                                            >
+                                                                                <TrashIcon className="w-5 h-5" />
+                                                                            </button>
+                                                                        </div>
+                                                                    </li>
+                                                                ))}
+                                                            </ul>
                                                         </div>
-                                                        <div className="flex gap-2">
-                                                            <button
-                                                                onClick={() => setEditingMedication(med)}
-                                                                className="p-2 text-blue-500 hover:bg-blue-100 rounded-full transition-colors"
-                                                                aria-label="Editar medicamento"
-                                                            >
-                                                                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21.036H3v-4.5L16.732 3.732z" /></svg>
-                                                            </button>
-                                                            <button
-                                                                onClick={() => removeMedication(med.id)}
-                                                                className="p-2 text-red-500 hover:bg-red-100 rounded-full transition-colors"
-                                                                aria-label="Eliminar medicamento"
-                                                            >
-                                                                <TrashIcon className="w-5 h-5" />
-                                                            </button>
-                                                        </div>
-                                                    </li>
+                                                    )
                                                 ))}
-                                            </ul>
+                                            </div>
                                         </div>
                                     )}
                                 </>

--- a/App.tsx
+++ b/App.tsx
@@ -45,7 +45,7 @@ const medicationCategoryOrder = [
 ];
 
 const medicationCategoryLabels: Record<MedicationCategory, string> = {
-    [MedicationCategory.CARDIOVASCULAR]: 'Cardiovascular / Hipertensión',
+    [MedicationCategory.CARDIOVASCULAR]: 'Cardiovascular',
     [MedicationCategory.DIABETES]: 'Diabetes',
     [MedicationCategory.INSULIN_GLP1]: 'Insulinas y agonistas GLP-1',
     [MedicationCategory.OTHER]: 'Otros',
@@ -87,6 +87,7 @@ const App: React.FC = () => {
     const [view, setView] = useState<'guide' | 'glycemia'>('guide');
     const [showAppsMenu, setShowAppsMenu] = useState(false);
     const [draggedMedicationId, setDraggedMedicationId] = useState<number | null>(null);
+    const [showCategoryLabels, setShowCategoryLabels] = useState(true);
 
     const previewRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -512,14 +513,25 @@ const App: React.FC = () => {
 
                 {/* Preview Panel */}
                 <div className="bg-slate-200 p-4 sm:p-6 rounded-xl shadow-inner flex items-start justify-center overflow-x-auto">
-                   <div ref={previewRef} className="w-full">
-                     <SchedulePreview
+                   <div className="w-full space-y-3">
+                     <label className="inline-flex items-center gap-2 text-xs text-slate-600 print:hidden">
+                       <input
+                         type="checkbox"
+                         className="rounded border-slate-300"
+                         checked={showCategoryLabels}
+                         onChange={(e) => setShowCategoryLabels(e.target.checked)}
+                       />
+                       Mostrar etiquetas por tipo en la tabla imprimible
+                     </label>
+                     <div ref={previewRef} className="w-full">
+                       <SchedulePreview
                        patient={patient}
                        medications={medications}
                        injectables={injectables}
                        inhalers={inhalers}
                        controlInfo={controlInfo}
                        showQr={showQr}
+                       showCategoryLabels={showCategoryLabels}
                        onEditMedication={(id) => {
                          const med = medications.find(m => m.id === id);
                          if (med) {
@@ -542,6 +554,7 @@ const App: React.FC = () => {
                          }
                        }}
                      />
+                     </div>
                    </div>
                 </div>
             </main>

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useRef, useCallback } from 'react';
-import { Patient, Medication, Injectable, ControlInfo, ExamOptions, Inhaler, DosageForm, MedicationCategory } from './types';
+import { Patient, Medication, Injectable, ControlInfo, ExamOptions, Inhaler, DosageForm, MedicationCategory, Frequency, InjectableSchedule } from './types';
 import PatientInfoForm from './components/PatientInfoForm';
 import MedicationForm from './components/MedicationForm';
 import InjectableForm from './components/InjectableForm';
@@ -78,6 +78,140 @@ const normalizeMedications = (meds: Medication[]): Medication[] => {
     return [...orderedByCategory, ...leftovers];
 };
 
+const testPatientData: { patient: Patient; medications: Medication[]; injectables: Injectable[]; inhalers: Inhaler[] } = {
+    patient: {
+        name: 'Juanito Perez',
+        rut: '17.752.753-K',
+        date: '2025-11-16',
+    },
+    medications: [
+        {
+            name: 'Metformina',
+            presentacion: '1000 mg',
+            dose: '1',
+            frequency: Frequency.EVERY_12H,
+            dosageForm: DosageForm.TABLET,
+            otherDosageForm: '',
+            notes: '',
+            isNewMedication: false,
+            doseIncreased: false,
+            doseDecreased: false,
+            requiresPurchase: false,
+            category: MedicationCategory.DIABETES,
+            id: 1763260676706,
+            order: 0,
+        },
+        {
+            name: 'Losartan ',
+            presentacion: '50 mg',
+            dose: '1',
+            frequency: Frequency.EVERY_12H,
+            dosageForm: DosageForm.TABLET,
+            otherDosageForm: '',
+            notes: '',
+            isNewMedication: false,
+            doseIncreased: false,
+            doseDecreased: false,
+            requiresPurchase: false,
+            category: MedicationCategory.CARDIOVASCULAR,
+            id: 1763260685881,
+            order: 0,
+        },
+        {
+            name: 'Aspirina',
+            presentacion: '100 mg',
+            dose: '1',
+            frequency: Frequency.EVERY_24H,
+            dosageForm: DosageForm.TABLET,
+            otherDosageForm: '',
+            notes: '',
+            isNewMedication: false,
+            doseIncreased: false,
+            doseDecreased: false,
+            requiresPurchase: false,
+            category: MedicationCategory.CARDIOVASCULAR,
+            id: 1763260713400,
+            order: 2,
+        },
+        {
+            name: 'Atorvastatina',
+            presentacion: '20 mg',
+            dose: '1',
+            frequency: Frequency.EVERY_24H_NIGHT,
+            dosageForm: DosageForm.TABLET,
+            otherDosageForm: '',
+            notes: '',
+            isNewMedication: false,
+            doseIncreased: false,
+            doseDecreased: false,
+            requiresPurchase: false,
+            category: MedicationCategory.CARDIOVASCULAR,
+            id: 1763260719664,
+            order: 3,
+        },
+        {
+            name: 'Pregabalina',
+            presentacion: '75 mg',
+            dose: '1',
+            frequency: Frequency.EVERY_24H_NIGHT,
+            dosageForm: DosageForm.TABLET,
+            otherDosageForm: '',
+            notes: '',
+            isNewMedication: false,
+            doseIncreased: false,
+            doseDecreased: false,
+            requiresPurchase: false,
+            category: MedicationCategory.OTHER,
+            id: 1763260734184,
+            order: 0,
+        },
+        {
+            name: 'Bisoprolol ',
+            presentacion: '2.5 mg',
+            dose: '1',
+            frequency: Frequency.EVERY_24H,
+            dosageForm: DosageForm.TABLET,
+            otherDosageForm: '',
+            notes: '',
+            isNewMedication: false,
+            doseIncreased: false,
+            doseDecreased: false,
+            requiresPurchase: false,
+            category: MedicationCategory.CARDIOVASCULAR,
+            id: 1763260805200,
+            order: 1,
+        },
+    ],
+    injectables: [
+        {
+            type: 'Insulina NPH',
+            dose: '6 U',
+            schedule: InjectableSchedule.MAÑANA,
+            time: '08:00',
+            notes: '',
+            isNewMedication: false,
+            doseIncreased: false,
+            doseDecreased: false,
+            requiresPurchase: false,
+            id: 1763260662497,
+        },
+    ],
+    inhalers: [
+        {
+            name: 'Salmeterol',
+            presentacion: '25 mcg ',
+            dose: 2,
+            frequencyHours: 12,
+            notes: '',
+            isNewMedication: false,
+            doseIncreased: false,
+            doseDecreased: false,
+            requiresPurchase: false,
+            id: 1763260746537,
+        },
+    ],
+};
+
 const App: React.FC = () => {
     const today = new Date().toISOString().split('T')[0];
     const [patient, setPatient] = useState<Patient>({ name: '', rut: '', date: today });
@@ -98,6 +232,17 @@ const App: React.FC = () => {
 
     const previewRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const getExportBaseName = useCallback(() => {
+        const sanitizeComponent = (value: string, fallback: string) => {
+            const raw = value?.trim() || fallback;
+            const cleaned = raw.replace(/[<>:"/\\|?*]/g, '').replace(/\s+/g, ' ').trim();
+            return cleaned || fallback;
+        };
+        const namePart = sanitizeComponent(patient.name, 'Paciente');
+        const datePart = sanitizeComponent(patient.date, today);
+        return `Lista de fármacos - ${namePart} - ${datePart}`;
+    }, [patient.name, patient.date, today]);
 
     const handlePatientChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = e.target;
@@ -195,7 +340,13 @@ const App: React.FC = () => {
     }, []);
 
     const handlePrint = () => {
+        const previousTitle = document.title;
+        const exportBaseName = getExportBaseName();
+        document.title = exportBaseName;
         window.print();
+        setTimeout(() => {
+            document.title = previousTitle;
+        }, 500);
     };
 
     const handleExportList = () => {
@@ -204,10 +355,18 @@ const App: React.FC = () => {
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = 'lista_farmacos.json';
+        const fileBaseName = getExportBaseName();
+        a.download = `${fileBaseName}.json`;
         a.click();
         URL.revokeObjectURL(url);
     };
+
+    const handleLoadTestPatient = useCallback(() => {
+        setPatient({ ...testPatientData.patient });
+        setMedications(normalizeMedications(testPatientData.medications.map(med => ({ ...med }))));
+        setInjectables(testPatientData.injectables.map(inj => ({ ...inj })));
+        setInhalers(testPatientData.inhalers.map(inh => ({ ...inh })));
+    }, []);
 
     const handleImportList = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
@@ -252,8 +411,19 @@ const App: React.FC = () => {
                     </div>
                     <div className="flex gap-2 items-center">
                         <button
+                            onClick={handleLoadTestPatient}
+                            className="bg-slate-600 hover:bg-slate-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-1"
+                            type="button"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
+                                <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
+                            </svg>
+                            Cargar paciente de prueba
+                        </button>
+                        <button
                             onClick={handleExportList}
                             className="bg-blue-600 hover:bg-blue-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-1"
+                            type="button"
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M3 3a2 2 0 012-2h6a2 2 0 012 2v3h-2V3H5v14h6v-3h2v3a2 2 0 01-2 2H5a2 2 0 01-2-2V3z"/><path d="M9 7h2v5h3l-4 4-4-4h3V7z"/></svg>
                             Exportar Lista
@@ -261,6 +431,7 @@ const App: React.FC = () => {
                         <button
                             onClick={handleImportClick}
                             className="bg-yellow-600 hover:bg-yellow-700 text-white font-bold text-xs py-1 px-2 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center gap-1"
+                            type="button"
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path d="M3 3a2 2 0 012-2h6a2 2 0 012 2v3h-2V3H5v14h6v-3h2v3a2 2 0 01-2 2H5a2 2 0 01-2-2V3z"/><path d="M11 13H9V8H6l4-4 4 4h-3v5z"/></svg>
                             Importar Lista

--- a/App.tsx
+++ b/App.tsx
@@ -40,14 +40,12 @@ const initialControlInfo: ControlInfo = {
 const medicationCategoryOrder = [
     MedicationCategory.CARDIOVASCULAR,
     MedicationCategory.DIABETES,
-    MedicationCategory.INSULIN_GLP1,
     MedicationCategory.OTHER,
 ];
 
 const medicationCategoryLabels: Record<MedicationCategory, string> = {
     [MedicationCategory.CARDIOVASCULAR]: 'Cardiovascular',
     [MedicationCategory.DIABETES]: 'Diabetes',
-    [MedicationCategory.INSULIN_GLP1]: 'Insulinas y agonistas GLP-1',
     [MedicationCategory.OTHER]: 'Otros',
 };
 
@@ -56,7 +54,15 @@ type MedicationInput = Omit<Medication, 'id' | 'order'>;
 const normalizeMedications = (meds: Medication[]): Medication[] => {
     const normalized = meds.map((med, index) => ({
         ...med,
-        category: med.category ?? MedicationCategory.OTHER,
+        category: (() => {
+            const incomingCategory = (med as Medication & { category?: string }).category;
+            if (incomingCategory === 'insulinas_glp1') {
+                return MedicationCategory.DIABETES;
+            }
+            return incomingCategory && Object.values(MedicationCategory).includes(incomingCategory as MedicationCategory)
+                ? incomingCategory as MedicationCategory
+                : MedicationCategory.OTHER;
+        })(),
         order: typeof med.order === 'number' ? med.order : index,
     }));
 
@@ -88,6 +94,7 @@ const App: React.FC = () => {
     const [showAppsMenu, setShowAppsMenu] = useState(false);
     const [draggedMedicationId, setDraggedMedicationId] = useState<number | null>(null);
     const [showCategoryLabels, setShowCategoryLabels] = useState(true);
+    const [showIcons, setShowIcons] = useState(true);
 
     const previewRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -523,6 +530,15 @@ const App: React.FC = () => {
                        />
                        Mostrar etiquetas por tipo en la tabla imprimible
                      </label>
+                     <label className="inline-flex items-center gap-2 text-xs text-slate-600 print:hidden">
+                       <input
+                         type="checkbox"
+                         className="rounded border-slate-300"
+                         checked={showIcons}
+                         onChange={(e) => setShowIcons(e.target.checked)}
+                       />
+                       Mostrar "Iconos" (texto e íconos asociados)
+                     </label>
                      <div ref={previewRef} className="w-full">
                        <SchedulePreview
                        patient={patient}
@@ -532,6 +548,7 @@ const App: React.FC = () => {
                        controlInfo={controlInfo}
                        showQr={showQr}
                        showCategoryLabels={showCategoryLabels}
+                       showIcons={showIcons}
                        onEditMedication={(id) => {
                          const med = medications.find(m => m.id === id);
                          if (med) {

--- a/components/InhalerForm.tsx
+++ b/components/InhalerForm.tsx
@@ -58,39 +58,39 @@ const InhalerForm: React.FC<InhalerFormProps> = ({ onAddInhaler, onUpdateInhaler
     };
 
     return (
-        <form onSubmit={handleSubmit} className="space-y-2 pt-2 border-t border-slate-200">
+        <form onSubmit={handleSubmit} className="space-y-2 pt-2 border-t border-slate-200 text-sm">
             <h2 className="text-2xl font-bold text-slate-800 border-b-2 border-blue-200 pb-2">
                 {editingInhaler ? 'Editar Inhalador' : 'Añadir Inhalador'}
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
-                    <label htmlFor="inhName" className="block text-sm font-medium text-slate-600 mb-1">Nombre del Medicamento</label>
+                    <label htmlFor="inhName" className="block text-xs font-medium text-slate-600 mb-1">Nombre del Medicamento</label>
                     <input
                         type="text"
                         id="inhName"
                         name="name"
                         value={inhaler.name}
                         onChange={handleChange}
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
                 <div>
-                    <label htmlFor="inhPres" className="block text-sm font-medium text-slate-600 mb-1">Presentación</label>
+                    <label htmlFor="inhPres" className="block text-xs font-medium text-slate-600 mb-1">Presentación</label>
                     <input
                         type="text"
                         id="inhPres"
                         name="presentacion"
                         value={inhaler.presentacion}
                         onChange={handleChange}
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
-                    <label htmlFor="inhDose" className="block text-sm font-medium text-slate-600 mb-1">Dosis (puff)</label>
+                    <label htmlFor="inhDose" className="block text-xs font-medium text-slate-600 mb-1">Dosis (puff)</label>
                     <input
                         type="number"
                         id="inhDose"
@@ -98,12 +98,12 @@ const InhalerForm: React.FC<InhalerFormProps> = ({ onAddInhaler, onUpdateInhaler
                         value={inhaler.dose}
                         onChange={handleChange}
                         min={0}
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
                 <div>
-                    <label htmlFor="inhFreq" className="block text-sm font-medium text-slate-600 mb-1">Frecuencia (cada X horas)</label>
+                    <label htmlFor="inhFreq" className="block text-xs font-medium text-slate-600 mb-1">Frecuencia (cada X horas)</label>
                     <input
                         type="number"
                         id="inhFreq"
@@ -111,13 +111,13 @@ const InhalerForm: React.FC<InhalerFormProps> = ({ onAddInhaler, onUpdateInhaler
                         value={inhaler.frequencyHours}
                         onChange={handleChange}
                         min={0}
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
             </div>
             <div className="grid grid-cols-2 gap-2">
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="isNewMedication"
@@ -127,7 +127,7 @@ const InhalerForm: React.FC<InhalerFormProps> = ({ onAddInhaler, onUpdateInhaler
                     />
                     Nuevo medicamento
                 </label>
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="doseIncreased"
@@ -137,7 +137,7 @@ const InhalerForm: React.FC<InhalerFormProps> = ({ onAddInhaler, onUpdateInhaler
                     />
                     Aumento de dosis
                 </label>
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="doseDecreased"
@@ -147,7 +147,7 @@ const InhalerForm: React.FC<InhalerFormProps> = ({ onAddInhaler, onUpdateInhaler
                     />
                     Disminución de dosis
                 </label>
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="requiresPurchase"
@@ -159,14 +159,14 @@ const InhalerForm: React.FC<InhalerFormProps> = ({ onAddInhaler, onUpdateInhaler
                 </label>
             </div>
             <div>
-                <label htmlFor="inhNotes" className="block text-sm font-medium text-slate-600 mb-1">Notas (Opcional)</label>
+                <label htmlFor="inhNotes" className="block text-xs font-medium text-slate-600 mb-1">Notas (Opcional)</label>
                 <textarea
                     id="inhNotes"
                     name="notes"
                     value={inhaler.notes}
                     onChange={handleChange}
                     rows={2}
-                    className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                    className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                 />
             </div>
             <div className="flex gap-2">

--- a/components/InjectableForm.tsx
+++ b/components/InjectableForm.tsx
@@ -130,13 +130,13 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
     };
 
     return (
-        <form onSubmit={handleSubmit} className="space-y-4 pt-4 border-t border-slate-200">
+        <form onSubmit={handleSubmit} className="space-y-4 pt-4 border-t border-slate-200 text-sm">
             <h2 className="text-2xl font-bold text-slate-800 border-b-2 border-blue-200 pb-2">
                 {editingInjectable ? 'Editar Fármaco Inyectable' : 'Añadir Fármaco Inyectable'}
             </h2>
 
             <div>
-                <label htmlFor="injectableType" className="block text-sm font-medium text-slate-600 mb-1">
+                <label htmlFor="injectableType" className="block text-xs font-medium text-slate-600 mb-1">
                     Tipo de Tratamiento
                 </label>
                 <select
@@ -144,7 +144,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                     name="type"
                     value={injectable.type}
                     onChange={handleTypeChange}
-                    className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                    className="w-full px-3 py-2 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                 >
                     {Object.values(InjectableType).map(type => (
                         <option key={type} value={type}>{type}</option>
@@ -153,7 +153,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                 {injectable.type === InjectableType.OTHER && (
                     <input
                         type="text"
-                        className="mt-2 w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="mt-2 w-full px-3 py-2 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         placeholder="Especificar"
                         value={customType}
                         onChange={e => setCustomType(e.target.value)}
@@ -163,7 +163,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
 
             {insulinTypes.includes(injectable.type) && (
                 <div>
-                    <label htmlFor="injectableDose" className="block text-sm font-medium text-slate-600 mb-1">Dosis (Unidades)</label>
+                    <label htmlFor="injectableDose" className="block text-xs font-medium text-slate-600 mb-1">Dosis (Unidades)</label>
                     <input
                         type="number"
                         id="injectableDose"
@@ -172,7 +172,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                         onChange={handleChange}
                         min="0"
                         placeholder="Ej: 10"
-                        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full px-3 py-2 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
@@ -180,12 +180,12 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
 
             {injectable.type === InjectableType.SEMAGLUTIDE && (
                 <div>
-                    <label className="block text-sm font-medium text-slate-600 mb-1">Dosis (mg/sem)</label>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Dosis (mg/sem)</label>
                     <select
                         name="dose"
                         value={injectable.dose}
                         onChange={handleChange}
-                        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                        className="w-full px-3 py-2 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                     >
                         <option value="0.25 mg/sem">0.25 mg/sem</option>
                         <option value="0.5 mg/sem">0.5 mg/sem</option>
@@ -196,7 +196,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                     {injectable.dose === 'other' && (
                         <input
                             type="text"
-                            className="mt-2 w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                            className="mt-2 w-full px-3 py-2 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                             placeholder="Ej: 1.5 mg/sem"
                             value={customDose}
                             onChange={e => setCustomDose(e.target.value)}
@@ -207,12 +207,12 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
 
             {injectable.type === InjectableType.LIRAGLUTIDE && (
                 <div>
-                    <label className="block text-sm font-medium text-slate-600 mb-1">Dosis (mg/día)</label>
+                    <label className="block text-xs font-medium text-slate-600 mb-1">Dosis (mg/día)</label>
                     <select
                         name="dose"
                         value={injectable.dose}
                         onChange={handleChange}
-                        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                        className="w-full px-3 py-2 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                     >
                         <option value="0.6 mg/día">0.6 mg/día</option>
                         <option value="1.2 mg/día">1.2 mg/día</option>
@@ -223,13 +223,13 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
-                    <label htmlFor="schedule" className="block text-sm font-medium text-slate-600 mb-1">Horario</label>
+                    <label htmlFor="schedule" className="block text-xs font-medium text-slate-600 mb-1">Horario</label>
                     <select
                         id="schedule"
                         name="schedule"
                         value={injectable.schedule}
                         onChange={handleChange}
-                        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                        className="w-full px-3 py-2 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                     >
                         {scheduleOptions.map(s => (
                             <option key={s} value={s}>{s}</option>
@@ -238,13 +238,13 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                 </div>
                 {!isRapid && (
                 <div>
-                    <label htmlFor="time" className="block text-sm font-medium text-slate-600 mb-1">Indicar Hora</label>
+                    <label htmlFor="time" className="block text-xs font-medium text-slate-600 mb-1">Indicar Hora</label>
                     <select
                         id="time"
                         name="time"
                         value={injectable.time}
                         onChange={handleChange}
-                        className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                        className="w-full px-3 py-2 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                         required
                     >
                         {hourOptions.map(hour => (
@@ -256,7 +256,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
             </div>
 
             <div className="grid grid-cols-2 gap-2">
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="isNewMedication"
@@ -266,7 +266,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                     />
                     Nuevo medicamento
                 </label>
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="doseIncreased"
@@ -276,7 +276,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                     />
                     Aumento de dosis
                 </label>
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="doseDecreased"
@@ -286,7 +286,7 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
                     />
                     Disminución de dosis
                 </label>
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="requiresPurchase"
@@ -299,14 +299,14 @@ const InjectableForm: React.FC<InjectableFormProps> = ({ onAddInjectable, onUpda
             </div>
 
             <div>
-                <label htmlFor="injectable_notes" className="block text-sm font-medium text-slate-600 mb-1">Notas (Opcional)</label>
+                <label htmlFor="injectable_notes" className="block text-xs font-medium text-slate-600 mb-1">Notas (Opcional)</label>
                 <textarea
                     id="injectable_notes"
                     name="notes"
                     value={injectable.notes}
                     onChange={handleChange}
                     rows={2}
-                    className="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                    className="w-full px-3 py-2 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                     placeholder="Ej: Medir glicemia antes de administrar"
                 />
             </div>

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -74,13 +74,13 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
     };
 
     return (
-        <form onSubmit={handleSubmit} className="space-y-2 pt-2 border-t border-slate-200">
+        <form onSubmit={handleSubmit} className="space-y-2 pt-2 border-t border-slate-200 text-sm">
             <h2 className="text-xl font-bold text-slate-800 border-b-2 border-blue-200 pb-2">
                 {editingMedication ? 'Editar Fármaco Oral' : 'Añadir Fármaco Oral'}
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
-                    <label htmlFor="medName" className="block text-sm font-medium text-slate-600 mb-1">Nombre del Medicamento</label>
+                    <label htmlFor="medName" className="block text-xs font-medium text-slate-600 mb-1">Nombre del Medicamento</label>
                     <input
                         type="text"
                         id="medName"
@@ -88,12 +88,12 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                         value={medication.name}
                         onChange={handleChange}
                         placeholder="Ej: Losartán"
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
                 <div>
-                    <label htmlFor="presentacion" className="block text-sm font-medium text-slate-600 mb-1">Presentación</label>
+                    <label htmlFor="presentacion" className="block text-xs font-medium text-slate-600 mb-1">Presentación</label>
                     <input
                         type="text"
                         id="presentacion"
@@ -101,36 +101,36 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                         value={medication.presentacion}
                         onChange={handleChange}
                         placeholder="Ej: 50mg"
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         required
                     />
                 </div>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
                 <div>
-                    <label htmlFor="category" className="block text-sm font-medium text-slate-600 mb-1">Categoría</label>
+                    <label htmlFor="category" className="block text-xs font-medium text-slate-600 mb-1">Categoría</label>
                     <select
                         id="category"
                         name="category"
                         value={medication.category}
                         onChange={handleChange}
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                        className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                     >
-                        <option value={MedicationCategory.CARDIOVASCULAR}>Cardiovascular / Hipertensión</option>
+                        <option value={MedicationCategory.CARDIOVASCULAR}>Cardiovascular</option>
                         <option value={MedicationCategory.DIABETES}>Diabetes</option>
                         <option value={MedicationCategory.INSULIN_GLP1}>Insulinas y Agonistas GLP-1</option>
                         <option value={MedicationCategory.OTHER}>Otros</option>
                     </select>
                 </div>
                 <div>
-                    <label htmlFor="dose" className="block text-sm font-medium text-slate-600 mb-1">Dosis</label>
+                    <label htmlFor="dose" className="block text-xs font-medium text-slate-600 mb-1">Dosis</label>
                     {medication.dosageForm === DosageForm.TABLET ? (
                         <select
                             id="dose"
                             name="dose"
                             value={medication.dose}
                             onChange={handleChange}
-                            className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                            className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                         >
                             {Object.values(Dose).map(d => (
                                 <option key={d} value={d}>{d}</option>
@@ -143,18 +143,18 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                             name="dose"
                             value={medication.dose}
                             onChange={handleChange}
-                            className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                            className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                         />
                     )}
                 </div>
                 <div>
-                    <label htmlFor="frequency" className="block text-sm font-medium text-slate-600 mb-1">Frecuencia</label>
+                    <label htmlFor="frequency" className="block text-xs font-medium text-slate-600 mb-1">Frecuencia</label>
                     <select
                         id="frequency"
                         name="frequency"
                         value={medication.frequency}
                         onChange={handleChange}
-                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                        className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                     >
                         {Object.values(Frequency).map(freq => (
                             <option key={freq} value={freq}>{freq}</option>
@@ -162,14 +162,14 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     </select>
                 </div>
                 <div>
-                    <label htmlFor="dosageForm" className="block text-sm font-medium text-slate-600 mb-1">Descripción</label>
+                    <label htmlFor="dosageForm" className="block text-xs font-medium text-slate-600 mb-1">Descripción</label>
                     <div className="flex gap-2">
                         <select
                             id="dosageForm"
                             name="dosageForm"
                             value={medication.dosageForm}
                             onChange={handleChange}
-                            className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                            className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
                         >
                             {Object.values(DosageForm).map(form => (
                                 <option key={form} value={form}>{form}</option>
@@ -181,7 +181,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                                 name="otherDosageForm"
                                 value={medication.otherDosageForm}
                                 onChange={handleChange}
-                                className="flex-1 px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                                className="flex-1 px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                                 placeholder="Especificar"
                             />
                         )}
@@ -189,7 +189,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                 </div>
             </div>
             <div className="grid grid-cols-2 gap-2">
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="isNewMedication"
@@ -199,7 +199,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     />
                     Nuevo medicamento
                 </label>
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="doseIncreased"
@@ -209,7 +209,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     />
                     Aumento de dosis
                 </label>
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="doseDecreased"
@@ -219,7 +219,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     />
                     Disminución de dosis
                 </label>
-                <label className="flex items-center text-sm text-slate-600">
+                <label className="flex items-center text-xs text-slate-600">
                     <input
                         type="checkbox"
                         name="requiresPurchase"
@@ -231,7 +231,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                 </label>
             </div>
             <div>
-                <label htmlFor="notes" className="block text-sm font-medium text-slate-600 mb-1">Notas (Opcional)</label>
+                <label htmlFor="notes" className="block text-xs font-medium text-slate-600 mb-1">Notas (Opcional)</label>
                 <textarea
                     id="notes"
                     name="notes"
@@ -239,7 +239,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     onChange={handleChange}
                     placeholder="Ej: Tomar con abundante agua"
                     rows={2}
-                    className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                    className="w-full px-2 py-1 text-sm border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                 />
             </div>
             <div className="flex gap-2">

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -1,16 +1,18 @@
 
 import React, { useState, useEffect } from 'react';
-import { Medication, Frequency, Dose, DosageForm } from '../types';
+import { Medication, Frequency, Dose, DosageForm, MedicationCategory } from '../types';
 import PlusIcon from './icons/PlusIcon';
 
+type MedicationFormData = Omit<Medication, 'id' | 'order'>;
+
 interface MedicationFormProps {
-    onAddMedication: (med: Omit<Medication, 'id'>) => void;
-    onUpdateMedication?: (id: number, med: Omit<Medication, 'id'>) => void;
+    onAddMedication: (med: MedicationFormData) => void;
+    onUpdateMedication?: (id: number, med: MedicationFormData) => void;
     editingMedication?: Medication | null;
     onCancelEdit?: () => void;
 }
 
-const initialMedState: Omit<Medication, 'id'> = {
+const initialMedState: MedicationFormData = {
     name: '',
     presentacion: '',
     dose: Dose.ONE,
@@ -22,6 +24,7 @@ const initialMedState: Omit<Medication, 'id'> = {
     doseIncreased: false,
     doseDecreased: false,
     requiresPurchase: false,
+    category: MedicationCategory.CARDIOVASCULAR,
 };
 
 const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpdateMedication, editingMedication, onCancelEdit }) => {
@@ -29,7 +32,7 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
 
     useEffect(() => {
         if (editingMedication) {
-            const { id, ...rest } = editingMedication;
+            const { id, order, ...rest } = editingMedication;
             setMedication(rest);
         } else {
             setMedication(initialMedState);
@@ -103,7 +106,22 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     />
                 </div>
             </div>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
+                <div>
+                    <label htmlFor="category" className="block text-sm font-medium text-slate-600 mb-1">Categoría</label>
+                    <select
+                        id="category"
+                        name="category"
+                        value={medication.category}
+                        onChange={handleChange}
+                        className="w-full px-2 py-1 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white"
+                    >
+                        <option value={MedicationCategory.CARDIOVASCULAR}>Cardiovascular / Hipertensión</option>
+                        <option value={MedicationCategory.DIABETES}>Diabetes</option>
+                        <option value={MedicationCategory.INSULIN_GLP1}>Insulinas y Agonistas GLP-1</option>
+                        <option value={MedicationCategory.OTHER}>Otros</option>
+                    </select>
+                </div>
                 <div>
                     <label htmlFor="dose" className="block text-sm font-medium text-slate-600 mb-1">Dosis</label>
                     {medication.dosageForm === DosageForm.TABLET ? (

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -118,7 +118,6 @@ const MedicationForm: React.FC<MedicationFormProps> = ({ onAddMedication, onUpda
                     >
                         <option value={MedicationCategory.CARDIOVASCULAR}>Cardiovascular</option>
                         <option value={MedicationCategory.DIABETES}>Diabetes</option>
-                        <option value={MedicationCategory.INSULIN_GLP1}>Insulinas y Agonistas GLP-1</option>
                         <option value={MedicationCategory.OTHER}>Otros</option>
                     </select>
                 </div>

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -20,17 +20,17 @@ interface SchedulePreviewProps {
     controlInfo: ControlInfo;
     showQr: boolean;
     showCategoryLabels: boolean;
+    showIcons: boolean;
     onEditMedication?: (id: number) => void;
     onEditInjectable?: (id: number) => void;
     onEditInhaler?: (id: number) => void;
 }
 
-const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, inhalers, controlInfo, showQr, showCategoryLabels, onEditMedication, onEditInjectable, onEditInhaler }) => {
+const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, inhalers, controlInfo, showQr, showCategoryLabels, showIcons, onEditMedication, onEditInjectable, onEditInhaler }) => {
 
     const medicationDisplayCategories: MedicationCategory[] = [
         MedicationCategory.CARDIOVASCULAR,
         MedicationCategory.DIABETES,
-        MedicationCategory.INSULIN_GLP1,
         MedicationCategory.OTHER,
     ];
 
@@ -39,7 +39,6 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
     const previewCategoryLabels: Record<MedicationCategory | 'inhalers', string> = {
         [MedicationCategory.CARDIOVASCULAR]: 'Cardiovascular',
         [MedicationCategory.DIABETES]: 'Diabetes',
-        [MedicationCategory.INSULIN_GLP1]: 'Insulinas y agonistas GLP-1',
         [MedicationCategory.OTHER]: 'Otros',
         inhalers: 'Inhaladores',
     };
@@ -151,7 +150,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
         doseIncreased: data.doseIncreased,
         doseDecreased: data.doseDecreased,
         requiresPurchase: data.requiresPurchase,
-        category: MedicationCategory.INSULIN_GLP1 as const,
+        category: MedicationCategory.DIABETES as const,
     }));
 
     const getDisplayTime = (ins: Injectable): string => {
@@ -175,7 +174,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
             itemsForCategory = inhalerItems;
         } else {
             const meds = medicationItemsByCategory.find(group => group.category === category)?.items ?? [];
-            itemsForCategory = category === MedicationCategory.INSULIN_GLP1
+            itemsForCategory = category === MedicationCategory.DIABETES
                 ? [...meds, ...injectableItems]
                 : meds;
         }
@@ -240,15 +239,17 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                 </div>
             </header>
 
-            <section className="mb-3 text-[11px] leading-tight text-slate-600">
-                <p className="font-semibold mb-1">Iconos:</p>
-                <ul className="flex flex-wrap gap-4">
-                    <li className="flex items-center gap-1"><ArrowUpIcon className="w-4 h-4"/> Aumento de dosis</li>
-                    <li className="flex items-center gap-1"><ArrowDownIcon className="w-4 h-4"/> Disminución de dosis</li>
-                    <li className="flex items-center gap-1"><StarIcon className="w-4 h-4 text-yellow-500"/> Nuevo medicamento</li>
-                    <li className="flex items-center gap-1"><MoneyIcon className="w-4 h-4 text-green-600"/> Comprar afuera</li>
-                </ul>
-            </section>
+            {showIcons && (
+                <section className="mb-3 text-[11px] leading-tight text-slate-600">
+                    <p className="font-semibold mb-1">Iconos:</p>
+                    <ul className="flex flex-wrap gap-4">
+                        <li className="flex items-center gap-1"><ArrowUpIcon className="w-4 h-4"/> Aumento de dosis</li>
+                        <li className="flex items-center gap-1"><ArrowDownIcon className="w-4 h-4"/> Disminución de dosis</li>
+                        <li className="flex items-center gap-1"><StarIcon className="w-4 h-4 text-yellow-500"/> Nuevo medicamento</li>
+                        <li className="flex items-center gap-1"><MoneyIcon className="w-4 h-4 text-green-600"/> Comprar afuera</li>
+                    </ul>
+                </section>
+            )}
 
             <section>
                 <div className="overflow-x-auto">
@@ -308,22 +309,22 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                             </td>
                                             <td className="px-2 py-1 align-top text-center">
                                                 <p className="font-bold text-sm text-slate-800 flex items-center justify-center gap-1">
-                                                    {item.isNewMedication && (
+                                                    {showIcons && item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
                                                         </span>
                                                     )}
-                                                    {item.doseIncreased && (
+                                                    {showIcons && item.doseIncreased && (
                                                         <span contentEditable={false}>
                                                             <ArrowUpIcon className="inline w-4 h-4" />
                                                         </span>
                                                     )}
-                                                    {item.doseDecreased && (
+                                                    {showIcons && item.doseDecreased && (
                                                         <span contentEditable={false}>
                                                             <ArrowDownIcon className="inline w-4 h-4" />
                                                         </span>
                                                     )}
-                                                    {item.requiresPurchase && (
+                                                    {showIcons && item.requiresPurchase && (
                                                         <span contentEditable={false}>
                                                             <MoneyIcon className="inline w-4 h-4 text-green-600" />
                                                         </span>
@@ -425,22 +426,22 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                             </td>
                                             <td className="px-2 py-1 align-top text-center">
                                                 <p className="font-bold text-sm text-slate-800 flex items-center justify-center gap-1">
-                                                    {item.isNewMedication && (
+                                                    {showIcons && item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
                                                         </span>
                                                     )}
-                                                    {item.doseIncreased && (
+                                                    {showIcons && item.doseIncreased && (
                                                         <span contentEditable={false}>
                                                             <ArrowUpIcon className="inline w-4 h-4" />
                                                         </span>
                                                     )}
-                                                    {item.doseDecreased && (
+                                                    {showIcons && item.doseDecreased && (
                                                         <span contentEditable={false}>
                                                             <ArrowDownIcon className="inline w-4 h-4" />
                                                         </span>
                                                     )}
-                                                    {item.requiresPurchase && (
+                                                    {showIcons && item.requiresPurchase && (
                                                         <span contentEditable={false}>
                                                             <MoneyIcon className="inline w-4 h-4 text-green-600" />
                                                         </span>
@@ -489,29 +490,29 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                             </td>
                                             <td className="px-2 py-1 align-top text-center">
                                                 <p className="font-bold text-sm text-slate-800 flex items-center justify-center gap-1">
-                                                    {item.isNewMedication && (
+                                                    {showIcons && item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
                                                         </span>
                                                     )}
-                                                    {item.doseIncreased && (
+                                                    {showIcons && item.doseIncreased && (
                                                         <span contentEditable={false}>
                                                             <ArrowUpIcon className="inline w-4 h-4" />
                                                         </span>
                                                     )}
-                                                    {item.doseDecreased && (
+                                                    {showIcons && item.doseDecreased && (
                                                         <span contentEditable={false}>
                                                             <ArrowDownIcon className="inline w-4 h-4" />
                                                         </span>
                                                     )}
-                                                    {item.requiresPurchase && (
+                                                    {showIcons && item.requiresPurchase && (
                                                         <span contentEditable={false}>
                                                             <MoneyIcon className="inline w-4 h-4 text-green-600" />
                                                         </span>
                                                     )}
                                                     {item.type}
                                                 </p>
-                                                <SyringeIcon className="w-4 h-4 text-teal-600 mx-auto" />
+                                                {showIcons && <SyringeIcon className="w-4 h-4 text-teal-600 mx-auto" />}
                                             </td>
                                             <td className="px-2 py-1 text-center align-middle text-[11px]" contentEditable={false}>
                                                 <div className="flex flex-row flex-wrap justify-center items-center gap-1.5">

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -373,7 +373,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                                 <DoseVisualizer
                                                                     dose={doses.afternoon || ''}
                                                                     dosageForm={item.dosageForm}
-                                                                    className="text-amber-500"
+                                                                    className="text-blue-600"
                                                                     editable={! [DosageForm.TABLET, DosageForm.NONE].includes(item.dosageForm)}
                                                                     onDoseChange={(val) => handleDoseInputChange(item.id, 'afternoon', val)}
                                                                 />

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Patient, Medication, Frequency, Dose, DosageForm, Injectable, InjectableSchedule, ControlInfo, Inhaler } from '../types';
+import { Patient, Medication, Frequency, Dose, DosageForm, Injectable, InjectableSchedule, ControlInfo, Inhaler, MedicationCategory } from '../types';
 import DoseVisualizer from './DoseVisualizer';
 import MoonIcon from './icons/MoonIcon';
 import SunIcon from './icons/SunIcon';
@@ -25,6 +25,23 @@ interface SchedulePreviewProps {
 }
 
 const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, inhalers, controlInfo, showQr, onEditMedication, onEditInjectable, onEditInhaler }) => {
+
+    const medicationDisplayCategories: MedicationCategory[] = [
+        MedicationCategory.CARDIOVASCULAR,
+        MedicationCategory.DIABETES,
+        MedicationCategory.INSULIN_GLP1,
+        MedicationCategory.OTHER,
+    ];
+
+    const previewCategoryOrder: Array<MedicationCategory | 'inhalers'> = [...medicationDisplayCategories, 'inhalers'];
+
+    const previewCategoryLabels: Record<MedicationCategory | 'inhalers', string> = {
+        [MedicationCategory.CARDIOVASCULAR]: 'Cardiovascular / Hipertensión',
+        [MedicationCategory.DIABETES]: 'Diabetes',
+        [MedicationCategory.INSULIN_GLP1]: 'Insulinas y agonistas GLP-1',
+        [MedicationCategory.OTHER]: 'Otros',
+        inhalers: 'Inhaladores',
+    };
 
     const shouldShowDose = (freq: Frequency, time: 'morning' | 'afternoon' | 'night'): boolean => {
         switch (time) {
@@ -113,9 +130,15 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
         return acc;
     }, new Map<string, { mañana: Injectable[]; noche: Injectable[]; ad: Injectable[]; aa: Injectable[]; ao: Injectable[]; ac: Injectable[]; isNewMedication: boolean; doseIncreased: boolean; doseDecreased: boolean; requiresPurchase: boolean }>());
 
-    const medicationItems = medications.map(med => ({ ...med, itemType: 'medication' as const }));
+    const medicationItemsByCategory = medicationDisplayCategories.map(category => ({
+        category,
+        items: medications
+            .filter(med => med.category === category)
+            .sort((a, b) => a.order - b.order)
+            .map(med => ({ ...med, itemType: 'medication' as const })),
+    }));
 
-    const inhalerItems = inhalers.map(inh => ({ ...inh, itemType: 'inhaler' as const }));
+    const inhalerItems = inhalers.map(inh => ({ ...inh, itemType: 'inhaler' as const, category: 'inhalers' as const }));
 
     const injectableItems = Array.from(groupedInjectables.entries()).map(([type, data]) => ({
         id: type,
@@ -127,6 +150,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
         doseIncreased: data.doseIncreased,
         doseDecreased: data.doseDecreased,
         requiresPurchase: data.requiresPurchase,
+        category: MedicationCategory.INSULIN_GLP1 as const,
     }));
 
     const getDisplayTime = (ins: Injectable): string => {
@@ -134,7 +158,31 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
         return match ? match[1] : ins.time;
     };
 
-    const allItems = [...medicationItems, ...inhalerItems, ...injectableItems];
+    type ContentItem =
+        | (typeof medicationItemsByCategory[number]['items'][number])
+        | (typeof inhalerItems)[number]
+        | (typeof injectableItems)[number];
+
+    const orderedItems: Array<
+        | { itemType: 'categoryHeader'; category: MedicationCategory | 'inhalers'; label: string }
+        | ContentItem
+    > = [];
+
+    previewCategoryOrder.forEach(category => {
+        let itemsForCategory: ContentItem[] = [];
+        if (category === 'inhalers') {
+            itemsForCategory = inhalerItems;
+        } else {
+            const meds = medicationItemsByCategory.find(group => group.category === category)?.items ?? [];
+            itemsForCategory = category === MedicationCategory.INSULIN_GLP1
+                ? [...meds, ...injectableItems]
+                : meds;
+        }
+        if (itemsForCategory.length > 0) {
+            orderedItems.push({ itemType: 'categoryHeader', category, label: previewCategoryLabels[category] });
+            orderedItems.push(...itemsForCategory);
+        }
+    });
 
     const formattedControlDate = controlInfo.date ? new Date(`${controlInfo.date}T${controlInfo.time || '00:00'}`).toLocaleString('es-CL', { dateStyle: 'short', timeStyle: 'short' }) : '';
 
@@ -159,6 +207,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
 
     const qrLink = showQr ? `https://qreceta.netlify.app/htmla.html?nombre=${encodeURIComponent(patient.name)}&rut=${encodeURIComponent(patient.rut)}&fecha=${encodeURIComponent(patient.date)}&meds=${encodeURIComponent(medsParam)}` : '';
     const qrImageSrc = showQr ? `https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${encodeURIComponent(qrLink)}` : '';
+
+    let rowNumber = 0;
 
     return (
         <div id="schedule-preview" className="relative bg-white p-8 rounded-lg shadow-xl w-full max-w-4xl mx-auto border border-slate-200">
@@ -226,13 +276,21 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                             </tr>
                         </thead>
                         <tbody contentEditable suppressContentEditableWarning>
-                            {allItems.length > 0 ? allItems.map((item, index) => {
-                                if (item.itemType === 'medication') {
+                            {orderedItems.length > 0 ? orderedItems.map((item) => {
+                                if (item.itemType === 'categoryHeader') {
                                     return (
-                                        <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
+                                        <tr key={`header-${item.category}`} className="bg-slate-100">
+                                            <td colSpan={6} className="p-2 text-left text-xs font-bold uppercase tracking-wide text-slate-600">{item.label}</td>
+                                        </tr>
+                                    );
+                                }
+                                if (item.itemType === 'medication') {
+                                    rowNumber += 1;
+                                    return (
+                                        <tr key={item.id} className={`border-b border-slate-200 ${rowNumber % 2 === 1 ? 'bg-white' : 'bg-blue-50/50'}`}>
                                             <td className="p-2 text-center align-top">
                                                 <div className="flex items-center justify-center gap-1">
-                                                    <span>{index + 1}</span>
+                                                    <span>{rowNumber}</span>
                                                     {onEditMedication && (
                                                         <button
                                                             onClick={() => onEditMedication(item.id)}
@@ -341,14 +399,15 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                         </tr>
                                     );
                                 } else if (item.itemType === 'inhaler') {
+                                    rowNumber += 1;
                                     const showMorning = item.frequencyHours === 8 || item.frequencyHours === 12;
                                     const showAfternoon = item.frequencyHours === 8;
                                     const showNight = item.frequencyHours === 8 || item.frequencyHours === 12;
                                     return (
-                                        <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
+                                        <tr key={item.id} className={`border-b border-slate-200 ${rowNumber % 2 === 1 ? 'bg-white' : 'bg-blue-50/50'}`}>
                                             <td className="p-2 text-center align-top">
                                                 <div className="flex items-center justify-center gap-1">
-                                                    <span>{index + 1}</span>
+                                                    <span>{rowNumber}</span>
                                                     {onEditInhaler && (
                                                         <button
                                                             onClick={() => onEditInhaler(item.id)}
@@ -403,15 +462,16 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                         </tr>
                                     );
                                 } else { // item.itemType === 'injectable'
+                                    rowNumber += 1;
                                     const allNotes = [...item.schedules.mañana, ...item.schedules.noche, ...item.schedules.ad, ...item.schedules.aa, ...item.schedules.ao, ...item.schedules.ac]
                                         .map(ins => ins.notes)
                                         .filter(Boolean)
                                         .join('\n');
                                     return (
-                                        <tr key={item.id} className={`border-b border-slate-200 ${index % 2 === 0 ? 'bg-white' : 'bg-blue-50/50'}`}>
+                                        <tr key={item.id} className={`border-b border-slate-200 ${rowNumber % 2 === 1 ? 'bg-white' : 'bg-blue-50/50'}`}>
                                             <td className="p-2 text-center align-top">
                                                 <div className="flex items-center justify-center gap-1">
-                                                    <span>{index + 1}</span>
+                                                    <span>{rowNumber}</span>
                                                     {onEditInjectable && item.editId != null && (
                                                         <button
                                                             onClick={() => onEditInjectable(item.editId!)}

--- a/components/SchedulePreview.tsx
+++ b/components/SchedulePreview.tsx
@@ -19,12 +19,13 @@ interface SchedulePreviewProps {
     inhalers: Inhaler[];
     controlInfo: ControlInfo;
     showQr: boolean;
+    showCategoryLabels: boolean;
     onEditMedication?: (id: number) => void;
     onEditInjectable?: (id: number) => void;
     onEditInhaler?: (id: number) => void;
 }
 
-const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, inhalers, controlInfo, showQr, onEditMedication, onEditInjectable, onEditInhaler }) => {
+const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications, injectables, inhalers, controlInfo, showQr, showCategoryLabels, onEditMedication, onEditInjectable, onEditInhaler }) => {
 
     const medicationDisplayCategories: MedicationCategory[] = [
         MedicationCategory.CARDIOVASCULAR,
@@ -36,7 +37,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
     const previewCategoryOrder: Array<MedicationCategory | 'inhalers'> = [...medicationDisplayCategories, 'inhalers'];
 
     const previewCategoryLabels: Record<MedicationCategory | 'inhalers', string> = {
-        [MedicationCategory.CARDIOVASCULAR]: 'Cardiovascular / Hipertensión',
+        [MedicationCategory.CARDIOVASCULAR]: 'Cardiovascular',
         [MedicationCategory.DIABETES]: 'Diabetes',
         [MedicationCategory.INSULIN_GLP1]: 'Insulinas y agonistas GLP-1',
         [MedicationCategory.OTHER]: 'Otros',
@@ -179,7 +180,9 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                 : meds;
         }
         if (itemsForCategory.length > 0) {
-            orderedItems.push({ itemType: 'categoryHeader', category, label: previewCategoryLabels[category] });
+            if (showCategoryLabels) {
+                orderedItems.push({ itemType: 'categoryHeader', category, label: previewCategoryLabels[category] });
+            }
             orderedItems.push(...itemsForCategory);
         }
     });
@@ -211,8 +214,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
     let rowNumber = 0;
 
     return (
-        <div id="schedule-preview" className="relative bg-white p-8 rounded-lg shadow-xl w-full max-w-4xl mx-auto border border-slate-200">
-            <header className="mb-4 border-b-2 pb-4 border-slate-200 relative">
+        <div id="schedule-preview" className="relative bg-white p-6 md:p-8 rounded-lg shadow-xl w-full max-w-4xl mx-auto border border-slate-200">
+            <header className="mb-3 border-b-2 pb-3 border-slate-200 relative">
                 {showQr && (
                     <img
                         src={qrImageSrc}
@@ -220,8 +223,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                         className="absolute -top-8 -right-8 w-36 h-36"
                     />
                 )}
-                <h1 className="mt-0 mb-1 text-2xl font-extrabold text-blue-700 leading-tight sm:pr-40">Guía de Medicamentos</h1>
-                <div className="text-sm flex flex-wrap gap-x-4 gap-y-1 sm:pr-40 sm:mt-0 mt-36">
+                <h1 className="mt-0 mb-1 text-xl md:text-2xl font-extrabold text-blue-700 leading-tight sm:pr-40">Guía de Medicamentos</h1>
+                <div className="text-[11px] sm:text-xs leading-tight flex flex-wrap gap-x-3 gap-y-0.5 sm:pr-40 sm:mt-0 mt-36">
                     <div className="flex items-center">
                         <span className="font-bold text-slate-600">Nombre y Apellido:</span>
                         <span className="ml-1 text-slate-800">{patient.name || '...'}</span>
@@ -237,7 +240,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                 </div>
             </header>
 
-            <section className="mb-4 text-xs text-slate-600">
+            <section className="mb-3 text-[11px] leading-tight text-slate-600">
                 <p className="font-semibold mb-1">Iconos:</p>
                 <ul className="flex flex-wrap gap-4">
                     <li className="flex items-center gap-1"><ArrowUpIcon className="w-4 h-4"/> Aumento de dosis</li>
@@ -249,30 +252,30 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
 
             <section>
                 <div className="overflow-x-auto">
-                    <table className="w-full border-collapse">
+                    <table className="w-full border-collapse text-[11px] leading-tight">
                         <thead>
                             <tr className="bg-blue-600 text-white">
-                                <th className="p-2 text-center font-semibold text-sm w-12">#</th>
-                                <th className="p-2 text-left font-semibold text-sm w-1/3">Medicamento / Presentación</th>
-                                <th className="p-2 text-center font-semibold text-sm w-1/6">
+                                <th className="px-2 py-1 text-center font-semibold text-xs w-10">#</th>
+                                <th className="px-2 py-1 text-left font-semibold text-xs w-1/3">Medicamento / Presentación</th>
+                                <th className="px-2 py-1 text-center font-semibold text-xs w-1/6">
                                     <div className="flex flex-col items-center justify-center gap-0.5">
-                                        <SunIcon className="w-5 h-5" />
+                                        <SunIcon className="w-4 h-4" />
                                         <span>Mañana</span>
                                     </div>
                                 </th>
-                                <th className="p-2 text-center font-semibold text-sm w-1/6">
+                                <th className="px-2 py-1 text-center font-semibold text-xs w-1/6">
                                     <div className="flex flex-col items-center justify-center gap-0.5">
-                                        <SunIcon className="w-5 h-5" />
+                                        <SunIcon className="w-4 h-4" />
                                         <span>Tarde</span>
                                     </div>
                                 </th>
-                                <th className="p-2 text-center font-semibold text-sm w-1/6">
+                                <th className="px-2 py-1 text-center font-semibold text-xs w-1/6">
                                     <div className="flex flex-col items-center justify-center gap-0.5">
-                                        <MoonIcon className="w-5 h-5" />
+                                        <MoonIcon className="w-4 h-4" />
                                         <span>Noche</span>
                                     </div>
                                 </th>
-                                <th className="p-2 text-left font-semibold text-sm w-1/6">Notas</th>
+                                <th className="px-2 py-1 text-left font-semibold text-xs w-1/6">Notas</th>
                             </tr>
                         </thead>
                         <tbody contentEditable suppressContentEditableWarning>
@@ -280,7 +283,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                 if (item.itemType === 'categoryHeader') {
                                     return (
                                         <tr key={`header-${item.category}`} className="bg-slate-100">
-                                            <td colSpan={6} className="p-2 text-left text-xs font-bold uppercase tracking-wide text-slate-600">{item.label}</td>
+                                            <td colSpan={6} className="px-2 py-1 text-left text-[11px] font-bold uppercase tracking-wide text-slate-600">{item.label}</td>
                                         </tr>
                                     );
                                 }
@@ -288,7 +291,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                     rowNumber += 1;
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${rowNumber % 2 === 1 ? 'bg-white' : 'bg-blue-50/50'}`}>
-                                            <td className="p-2 text-center align-top">
+                                            <td className="px-2 py-1 text-center align-top text-[11px]">
                                                 <div className="flex items-center justify-center gap-1">
                                                     <span>{rowNumber}</span>
                                                     {onEditMedication && (
@@ -303,8 +306,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     )}
                                                 </div>
                                             </td>
-                                            <td className="p-2 align-top text-center">
-                                                <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
+                                            <td className="px-2 py-1 align-top text-center">
+                                                <p className="font-bold text-sm text-slate-800 flex items-center justify-center gap-1">
                                                     {item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
@@ -327,7 +330,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     )}
                                                     {item.name}
                                                 </p>
-                                                <p className="text-sm text-slate-600">{item.presentacion}</p>
+                                                <p className="text-xs text-slate-600">{item.presentacion}</p>
                                                 {(() => {
                                                     const description = item.dosageForm === DosageForm.OTHER
                                                         ? item.otherDosageForm
@@ -335,7 +338,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                             ? ''
                                                             : item.dosageForm;
                                                     return (
-                                                        <p className="text-xs text-slate-500 italic">
+                                                        <p className="text-[10px] text-slate-500 italic">
                                                             {`${item.dose}${description ? ` ${description}` : ''} - ${item.frequency}`}
                                                         </p>
                                                     );
@@ -346,7 +349,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                 return (
                                                     <>
                                                         <td
-                                                            className={`p-2 text-center align-middle ${[DosageForm.TABLET, DosageForm.NONE].includes(item.dosageForm) ? 'cursor-pointer' : 'cursor-text'}`}
+                                                            className={`px-2 py-1 text-center align-middle text-[11px] ${[DosageForm.TABLET, DosageForm.NONE].includes(item.dosageForm) ? 'cursor-pointer' : 'cursor-text'}`}
                                                             contentEditable={false}
                                                             onClick={() => handleDoseClick(item.id, 'morning')}
                                                         >
@@ -361,7 +364,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                             )}
                                                         </td>
                                                         <td
-                                                            className={`p-2 text-center align-middle ${[DosageForm.TABLET, DosageForm.NONE].includes(item.dosageForm) ? 'cursor-pointer' : 'cursor-text'}`}
+                                                            className={`px-2 py-1 text-center align-middle text-[11px] ${[DosageForm.TABLET, DosageForm.NONE].includes(item.dosageForm) ? 'cursor-pointer' : 'cursor-text'}`}
                                                             contentEditable={false}
                                                             onClick={() => handleDoseClick(item.id, 'afternoon')}
                                                         >
@@ -376,7 +379,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                             )}
                                                         </td>
                                                         <td
-                                                            className={`p-2 text-center align-middle ${[DosageForm.TABLET, DosageForm.NONE].includes(item.dosageForm) ? 'cursor-pointer' : 'cursor-text'}`}
+                                                            className={`px-2 py-1 text-center align-middle text-[11px] ${[DosageForm.TABLET, DosageForm.NONE].includes(item.dosageForm) ? 'cursor-pointer' : 'cursor-text'}`}
                                                             contentEditable={false}
                                                             onClick={() => handleDoseClick(item.id, 'night')}
                                                         >
@@ -393,7 +396,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     </>
                                                 );
                                             })()}
-                                            <td className="p-2 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
+                                            <td className="px-2 py-1 align-top text-[11px] text-slate-700 whitespace-pre-wrap break-words">
                                                 {item.notes || ''}
                                             </td>
                                         </tr>
@@ -405,7 +408,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                     const showNight = item.frequencyHours === 8 || item.frequencyHours === 12;
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${rowNumber % 2 === 1 ? 'bg-white' : 'bg-blue-50/50'}`}>
-                                            <td className="p-2 text-center align-top">
+                                            <td className="px-2 py-1 text-center align-top text-[11px]">
                                                 <div className="flex items-center justify-center gap-1">
                                                     <span>{rowNumber}</span>
                                                     {onEditInhaler && (
@@ -420,8 +423,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     )}
                                                 </div>
                                             </td>
-                                            <td className="p-2 align-top text-center">
-                                                <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
+                                            <td className="px-2 py-1 align-top text-center">
+                                                <p className="font-bold text-sm text-slate-800 flex items-center justify-center gap-1">
                                                     {item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
@@ -444,19 +447,19 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     )}
                                                     {item.name}
                                                 </p>
-                                                <p className="text-sm text-slate-600">{item.presentacion}</p>
-                                                <p className="text-xs text-slate-500 italic">{`${item.dose} puff - cada ${item.frequencyHours} h`}</p>
+                                                <p className="text-xs text-slate-600">{item.presentacion}</p>
+                                                <p className="text-[10px] text-slate-500 italic">{`${item.dose} puff - cada ${item.frequencyHours} h`}</p>
                                             </td>
-                                            <td className="p-2 text-center align-middle" contentEditable={false}>
+                                            <td className="px-2 py-1 text-center align-middle text-[11px]" contentEditable={false}>
                                                 {showMorning && <span className="font-bold">{`${item.dose} puff`}</span>}
                                             </td>
-                                            <td className="p-2 text-center align-middle" contentEditable={false}>
+                                            <td className="px-2 py-1 text-center align-middle text-[11px]" contentEditable={false}>
                                                 {showAfternoon && <span className="font-bold">{`${item.dose} puff`}</span>}
                                             </td>
-                                            <td className="p-2 text-center align-middle" contentEditable={false}>
+                                            <td className="px-2 py-1 text-center align-middle text-[11px]" contentEditable={false}>
                                                 {showNight && <span className="font-bold">{`${item.dose} puff`}</span>}
                                             </td>
-                                            <td className="p-2 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
+                                            <td className="px-2 py-1 align-top text-[11px] text-slate-700 whitespace-pre-wrap break-words">
                                                 {item.notes || ''}
                                             </td>
                                         </tr>
@@ -469,7 +472,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                         .join('\n');
                                     return (
                                         <tr key={item.id} className={`border-b border-slate-200 ${rowNumber % 2 === 1 ? 'bg-white' : 'bg-blue-50/50'}`}>
-                                            <td className="p-2 text-center align-top">
+                                            <td className="px-2 py-1 text-center align-top text-[11px]">
                                                 <div className="flex items-center justify-center gap-1">
                                                     <span>{rowNumber}</span>
                                                     {onEditInjectable && item.editId != null && (
@@ -484,8 +487,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     )}
                                                 </div>
                                             </td>
-                                            <td className="p-2 align-top text-center">
-                                                <p className="font-bold text-md text-slate-800 flex items-center justify-center gap-1">
+                                            <td className="px-2 py-1 align-top text-center">
+                                                <p className="font-bold text-sm text-slate-800 flex items-center justify-center gap-1">
                                                     {item.isNewMedication && (
                                                         <span contentEditable={false}>
                                                             <StarIcon className="inline w-4 h-4 text-yellow-500" />
@@ -508,17 +511,17 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     )}
                                                     {item.type}
                                                 </p>
-                                                <SyringeIcon className="w-5 h-5 text-teal-600 mx-auto" />
+                                                <SyringeIcon className="w-4 h-4 text-teal-600 mx-auto" />
                                             </td>
-                                            <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                <div className="flex flex-row flex-wrap justify-center items-center gap-2">
+                                            <td className="px-2 py-1 text-center align-middle text-[11px]" contentEditable={false}>
+                                                <div className="flex flex-row flex-wrap justify-center items-center gap-1.5">
                                                     {[...item.schedules.mañana, ...item.schedules.ad].map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={getDisplayTime(ins)} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
-                                            <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                <div className="flex flex-row flex-wrap justify-center items-center gap-2">
+                                            <td className="px-2 py-1 text-center align-middle text-[11px]" contentEditable={false}>
+                                                <div className="flex flex-row flex-wrap justify-center items-center gap-1.5">
                                                     {item.schedules.aa.map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={getDisplayTime(ins)} className="text-blue-600"/>
                                                     ))}
@@ -527,14 +530,14 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                                     ))}
                                                 </div>
                                             </td>
-                                            <td className="p-2 text-center align-middle" contentEditable={false}>
-                                                <div className="flex flex-row flex-wrap justify-center items-center gap-2">
+                                            <td className="px-2 py-1 text-center align-middle text-[11px]" contentEditable={false}>
+                                                <div className="flex flex-row flex-wrap justify-center items-center gap-1.5">
                                                     {[...item.schedules.ac, ...item.schedules.noche].map(ins => (
                                                         <InjectableDoseVisualizer key={ins.id} dose={ins.dose} time={getDisplayTime(ins)} className="text-blue-600"/>
                                                     ))}
                                                 </div>
                                             </td>
-                                            <td className="p-2 align-top text-sm text-slate-700 whitespace-pre-wrap break-words">
+                                            <td className="px-2 py-1 align-top text-[11px] text-slate-700 whitespace-pre-wrap break-words">
                                                 {allNotes}
                                             </td>
                                         </tr>
@@ -542,7 +545,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ patient, medications,
                                 }
                             }) : (
                                 <tr>
-                                    <td colSpan={6} className="text-center p-4 text-slate-500">
+                                    <td colSpan={6} className="text-center px-2 py-3 text-[11px] text-slate-500">
                                         <p>Añada un medicamento, inhalador o tratamiento inyectable para verlo aquí.</p>
                                     </td>
                                 </tr>

--- a/types.ts
+++ b/types.ts
@@ -33,7 +33,6 @@ export enum DosageForm {
 export enum MedicationCategory {
     CARDIOVASCULAR = 'cardiovascular',
     DIABETES = 'diabetes',
-    INSULIN_GLP1 = 'insulinas_glp1',
     OTHER = 'otros',
 }
 

--- a/types.ts
+++ b/types.ts
@@ -30,6 +30,13 @@ export enum DosageForm {
     NONE = '-',
 }
 
+export enum MedicationCategory {
+    CARDIOVASCULAR = 'cardiovascular',
+    DIABETES = 'diabetes',
+    INSULIN_GLP1 = 'insulinas_glp1',
+    OTHER = 'otros',
+}
+
 export interface Medication {
   id: number;
   name: string;
@@ -43,6 +50,8 @@ export interface Medication {
   doseIncreased?: boolean;
   doseDecreased?: boolean;
   requiresPurchase?: boolean;
+  category: MedicationCategory;
+  order: number;
 }
 
 export interface Patient {


### PR DESCRIPTION
## Summary
- add explicit medication categories and persist ordering metadata
- allow drag-and-drop reordering within categories while editing and expose a category selector in the oral form
- update the preview table to display grouped categories in the requested order and keep inhalers at the end

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d314e858832c847aa51fe2858d9b)